### PR TITLE
Kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ update-vendor:
 		github.com/op/go-logging \
 		github.com/spf13/cobra \
 		github.com/spf13/pflag \
+		github.com/YakLabs/k8s-client \
 		github.com/zillode/notify
 
 docker: $(BIN) $(SYNCTHING)

--- a/deps/github.com/YakLabs/k8s-client/.envrc
+++ b/deps/github.com/YakLabs/k8s-client/.envrc
@@ -1,0 +1,11 @@
+export GOBUILDDIR=$(pwd)/.gobuild
+export GOPATH=$GOBUILDDIR:$GOPATH
+PATH_add $GOBUILDDIR/bin
+
+if [ ! -e ${GOBUILDDIR} ]; then
+    mkdir -p ${GOBUILDDIR}/src/github.com/YakLabs/
+    ln -s ../../../.. ${GOBUILDDIR}/src/github.com/YakLabs/k8s-client
+fi
+
+# go get github.com/pkg/errors
+# go get github.com/google/gofuzz

--- a/deps/github.com/YakLabs/k8s-client/.gitignore
+++ b/deps/github.com/YakLabs/k8s-client/.gitignore
@@ -1,0 +1,25 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+.gobuild 
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/deps/github.com/YakLabs/k8s-client/LICENSE
+++ b/deps/github.com/YakLabs/k8s-client/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/deps/github.com/YakLabs/k8s-client/README.md
+++ b/deps/github.com/YakLabs/k8s-client/README.md
@@ -1,0 +1,57 @@
+k8s-client [![GoDoc](https://godoc.org/github.com/YakLabs/k8s-client?status.svg)](https://godoc.org/github.com/YakLabs/k8s-client)
+=======
+
+k8s-client is a Kubernetes client for Go.
+
+## Status
+
+k8s-client should be considered *alpha* quality.  The API is subject
+to change.
+
+k8s-client does not have 100% coverage of the Kubenretes API, but
+supports the common operations.  Submit an issue or PR for support of
+others.
+
+## Motivation
+
+The "official" Kubernetes client for Go is part of the Kubernetes
+project proper and lives within the main Kubernetes repository. It
+also requires a rather large number of dependencies.
+
+k8s-client is a small simple API client.
+
+## License
+
+[Apache 2 License](./LICENSE)
+
+k8s-client also includes parts of the Kubernetes code that is also
+under the Apache 2 License.
+
+## Usage
+
+See
+[![GoDoc](https://godoc.org/github.com/YakLabs/k8s-client?status.svg)](https://godoc.org/github.com/YakLabs/k8s-client)
+for documentation.
+
+## Testing
+
+To test the included [Kubernetes http client](./http/), I use
+[minikube](https://github.com/kubernetes/minikube) to start a local
+cluster. Then I run `kubectl proxy` to proxy to the local cluster
+without authentication (this makes testing easier). Then:
+
+```
+cd http
+go test -v
+```
+
+The tests will try to connect to Kubernetes at
+`http://127.0.0.1:8001`. This can be overriden using the `K8S_SERVER`
+environment value.
+
+## TODO
+
+- [ ] Mock client for testing
+- [ ] Better docs/examples
+- [ ] Support all the Kubernetes types and operations
+- [ ] Support watches

--- a/deps/github.com/YakLabs/k8s-client/affinity.go
+++ b/deps/github.com/YakLabs/k8s-client/affinity.go
@@ -1,0 +1,165 @@
+package client
+
+const (
+	// AffinityAnnotationKey represents the key of affinity data (json serialized)
+	// in the Annotations of a Pod.
+	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
+)
+
+type (
+	// Affinity is a group of affinity scheduling rules.
+	Affinity struct {
+		// Describes node affinity scheduling rules for the pod.
+		NodeAffinity *NodeAffinity `json:"nodeAffinity,omitempty"`
+		// Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+		PodAffinity *PodAffinity `json:"podAffinity,omitempty"`
+		// Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+		PodAntiAffinity *PodAntiAffinity `json:"podAntiAffinity,omitempty"`
+	}
+
+	// NodeAffinity is a group of node affinity scheduling rules.
+	NodeAffinity struct {
+		// If the affinity requirements specified by this field are not met at
+		// scheduling time, the pod will not be scheduled onto the node.
+		// If the affinity requirements specified by this field cease to be met
+		// at some point during pod execution (e.g. due to an update), the system
+		// may or may not try to eventually evict the pod from its node.
+		RequiredDuringSchedulingIgnoredDuringExecution *NodeSelector `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+
+		// The scheduler will prefer to schedule pods to nodes that satisfy
+		// the affinity expressions specified by this field, but it may choose
+		// a node that violates one or more of the expressions. The node that is
+		// most preferred is the one with the greatest sum of weights, i.e.
+		// for each node that meets all of the scheduling requirements (resource
+		// request, requiredDuringScheduling affinity expressions, etc.),
+		// compute a sum by iterating through the elements of this field and adding
+		// "weight" to the sum if the node matches the corresponding matchExpressions; the
+		// node(s) with the highest sum are the most preferred.
+		PreferredDuringSchedulingIgnoredDuringExecution []PreferredSchedulingTerm `json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	}
+
+	// PodAffinity is a group of inter pod affinity scheduling rules.
+	PodAffinity struct {
+		// RequiredDuringSchedulingRequiredDuringExecution []PodAffinityTerm  `json:"requiredDuringSchedulingRequiredDuringExecution,omitempty"`
+		// If the affinity requirements specified by this field are not met at
+		// scheduling time, the pod will not be scheduled onto the node.
+		// If the affinity requirements specified by this field cease to be met
+		// at some point during pod execution (e.g. due to a pod label update), the
+		// system may or may not try to eventually evict the pod from its node.
+		// When there are multiple elements, the lists of nodes corresponding to each
+		// podAffinityTerm are intersected, i.e. all terms must be satisfied.
+		RequiredDuringSchedulingIgnoredDuringExecution []PodAffinityTerm `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+
+		// The scheduler will prefer to schedule pods to nodes that satisfy
+		// the affinity expressions specified by this field, but it may choose
+		// a node that violates one or more of the expressions. The node that is
+		// most preferred is the one with the greatest sum of weights, i.e.
+		// for each node that meets all of the scheduling requirements (resource
+		// request, requiredDuringScheduling affinity expressions, etc.),
+		// compute a sum by iterating through the elements of this field and adding
+		// "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+		// node(s) with the highest sum are the most preferred.
+		PreferredDuringSchedulingIgnoredDuringExecution []WeightedPodAffinityTerm `json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	}
+
+	// PodAntiAffinity is a group of inter pod anti affinity scheduling rules.
+	PodAntiAffinity struct {
+		// RequiredDuringSchedulingRequiredDuringExecution []PodAffinityTerm  `json:"requiredDuringSchedulingRequiredDuringExecution,omitempty"`
+		// If the anti-affinity requirements specified by this field are not met at
+		// scheduling time, the pod will not be scheduled onto the node.
+		// If the anti-affinity requirements specified by this field cease to be met
+		// at some point during pod execution (e.g. due to a pod label update), the
+		// system may or may not try to eventually evict the pod from its node.
+		// When there are multiple elements, the lists of nodes corresponding to each
+		// podAffinityTerm are intersected, i.e. all terms must be satisfied.
+		RequiredDuringSchedulingIgnoredDuringExecution []PodAffinityTerm `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+
+		// The scheduler will prefer to schedule pods to nodes that satisfy
+		// the anti-affinity expressions specified by this field, but it may choose
+		// a node that violates one or more of the expressions. The node that is
+		// most preferred is the one with the greatest sum of weights, i.e.
+		// for each node that meets all of the scheduling requirements (resource
+		// request, requiredDuringScheduling anti-affinity expressions, etc.),
+		// compute a sum by iterating through the elements of this field and adding
+		// "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+		// node(s) with the highest sum are the most preferred.
+		PreferredDuringSchedulingIgnoredDuringExecution []WeightedPodAffinityTerm `json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	}
+
+	// NodeSelector represents the union of the results of one or more label queries
+	// over a set of nodes; that is, it represents the OR of the selectors represented
+	// by the node selector terms.
+	NodeSelector struct {
+		// Required. A list of node selector terms. The terms are ORed.
+		NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms"`
+	}
+
+	// An empty preferred scheduling term matches all objects with implicit weight 0
+	// (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+	PreferredSchedulingTerm struct {
+		// Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+		Weight int32 `json:"weight,omitempty"`
+
+		// A node selector term, associated with the corresponding weight.
+		Preference *NodeSelectorTerm `json:"preference,omitempty"`
+	}
+
+	// Defines a set of pods (namely those matching the labelSelector
+	// relative to the given namespace(s)) that this pod should be
+	// co-located (affinity) or not co-located (anti-affinity) with,
+	// where co-located is defined as running on a node whose value of
+	// the label with key <topologyKey> tches that of any node on which
+	// a pod of the set of pods is running
+	PodAffinityTerm struct {
+		// A label query over a set of resources, in this case pods.
+		LabelSelector *LabelSelector `json:"labelSelector,omitempty"`
+
+		// namespaces specifies which namespaces the labelSelector applies to (matches against);
+		// nil list means "this pod's namespace," empty list means "all namespaces"
+		// The json tag here is not "omitempty" since we need to distinguish nil and empty.
+		// See https://golang.org/pkg/encoding/json/#Marshal for more details.
+		Namespaces []string `json:"namespaces,omitempty"`
+
+		// This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+		// the labelSelector in the specified namespaces, where co-located is defined as running on a node
+		// whose value of the label with key topologyKey matches that of any node on which any of the
+		// selected pods is running.
+		// For PreferredDuringScheduling pod anti-affinity, empty topologyKey is interpreted as "all topologies"
+		// ("all topologies" here means all the topologyKeys indicated by scheduler command-line argument --failure-domains);
+		// for affinity and for RequiredDuringScheduling pod anti-affinity, empty topologyKey is not allowed.
+		TopologyKey string `json:"topologyKey,omitempty"`
+	}
+
+	// The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+	WeightedPodAffinityTerm struct {
+		// weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+		Weight int32 `json:"weight,omitempty"`
+
+		// Required. A pod affinity term, associated with the corresponding weight.
+		PodAffinityTerm PodAffinityTerm `json:"podAffinityTerm"`
+	}
+
+	// A null or empty node selector term matches no objects.
+	NodeSelectorTerm struct {
+		// Required. A list of node selector requirements. The requirements are ANDed.
+		MatchExpressions []NodeSelectorRequirement `json:"matchExpressions"`
+	}
+
+	// A node selector requirement is a selector that contains values, a key, and an operator
+	// that relates the key and values.
+	NodeSelectorRequirement struct {
+		// The label key that the selector applies to.
+		Key string `json:"key,omitempty"`
+
+		// Represents a key's relationship to a set of values.
+		// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+		Operator string `json:"operator,omitempty"`
+
+		// An array of string values. If the operator is In or NotIn,
+		// the values array must be non-empty. If the operator is Exists or DoesNotExist,
+		// the values array must be empty. If the operator is Gt or Lt, the values
+		// array must have a single element, which will be interpreted as an integer.
+		// This array is replaced during a strategic merge patch.
+		Values []string `json:"values,omitempty"`
+	}
+)

--- a/deps/github.com/YakLabs/k8s-client/client.go
+++ b/deps/github.com/YakLabs/k8s-client/client.go
@@ -1,0 +1,25 @@
+package client
+
+type (
+	// Client is an interface that represents a kubernetes client
+	Client interface {
+		ConfigMapInterface
+		DaemonSetInterface
+		DeploymentInterface
+		HorizontalPodAutoscalerInterface
+		IngressInterface
+		JobInterface
+		NamespaceInterface
+		NodeInterface
+		PodInterface
+		ReplicaSetInterface
+		SecretInterface
+		ServiceAccountInterface
+		ServiceInterface
+	}
+
+	ListOptions struct {
+		LabelSelector LabelSelector
+		FieldSelector FieldSelector
+	}
+)

--- a/deps/github.com/YakLabs/k8s-client/common.go
+++ b/deps/github.com/YakLabs/k8s-client/common.go
@@ -1,0 +1,124 @@
+package client
+
+// Common object elements
+
+type (
+	UID             string
+	FinalizerName   string
+	ConditionStatus string
+
+	TypeMeta struct {
+		Kind       string `json:"kind,omitempty"`
+		APIVersion string `json:"apiVersion,omitempty"`
+	}
+
+	ObjectMeta struct {
+		Name              string            `json:"name,omitempty"`
+		Namespace         string            `json:"namespace,omitempty"`
+		SelfLink          string            `json:"selfLink,omitempty"`
+		UID               UID               `json:"uid,omitempty"`
+		ResourceVersion   string            `json:"resourceVersion,omitempty"`
+		CreationTimestamp *Time             `json:"creationTimestamp,omitempty"`
+		DeletionTimestamp *Time             `json:"deletionTimestamp,omitempty"`
+		Generation        int64             `json:"generation,omitempty"`
+		Labels            map[string]string `json:"labels,omitempty"`
+		Annotations       map[string]string `json:"annotations,omitempty"`
+	}
+
+	ListMeta struct {
+		SelfLink        string `json:"selfLink,omitempty"`
+		ResourceVersion string `json:"resourceVersion,omitempty"`
+	}
+
+	ObjectReference struct {
+		Kind            string `json:"kind,omitempty"`
+		Namespace       string `json:"namespace,omitempty"`
+		Name            string `json:"name,omitempty"`
+		UID             UID    `json:"uid,omitempty"`
+		APIVersion      string `json:"apiVersion,omitempty"`
+		ResourceVersion string `json:"resourceVersion,omitempty"`
+		FieldPath       string `json:"fieldPath,omitempty"`
+	}
+
+	LocalObjectReference struct {
+		Name string `json:"name"`
+	}
+
+	ObjectFieldSelector struct {
+		APIVersion string `json:"apiVersion"`
+		FieldPath  string `json:"fieldPath"`
+	}
+
+	ConfigMapKeySelector struct {
+		LocalObjectReference `json:",inline"`
+		Key                  string `json:"key"`
+	}
+
+	SecretKeySelector struct {
+		LocalObjectReference `json:",inline"`
+		Key                  string `json:"key"`
+	}
+
+	LabelSelector struct {
+		// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+		// map is equivalent to an element of matchExpressions, whose key field is "key", the
+		// operator is "In", and the values array contains only "value". The requirements are ANDed.
+		MatchLabels map[string]string `json:"matchLabels,omitempty" protobuf:"bytes,1,rep,name=matchLabels"`
+	}
+
+	FieldSelector map[string]string
+
+	Object interface {
+		GetKind() string
+		GetAnnotations() map[string]string
+		GetLabels() map[string]string
+		SetLabels(labels map[string]string)
+	}
+
+	NamespacedObject interface {
+		Object
+		GetNamespace() string
+	}
+	ListObject interface {
+		Object
+		GetItems()
+	}
+)
+
+func (t *TypeMeta) GetKind() string {
+	return t.Kind
+}
+
+func (o *ObjectMeta) GetNamespace() string {
+	return o.Namespace
+}
+
+func (o *ObjectMeta) GetAnnotations() map[string]string {
+	return o.Annotations
+}
+
+func (o *ObjectMeta) GetLabels() map[string]string {
+	return o.Labels
+}
+
+func (o *ObjectMeta) SetLabels(labels map[string]string) {
+	o.Labels = labels
+}
+
+// NewTypeMeta creates a new TypeMeta and initializes the given kind & apiVersion
+func NewTypeMeta(kind, apiVersion string) TypeMeta {
+	return TypeMeta{
+		Kind:       kind,
+		APIVersion: apiVersion,
+	}
+}
+
+// NewObjectMeta creates a new ObjectMeta and initializes the given namespace, name & internal maps.
+func NewObjectMeta(namespace, name string) ObjectMeta {
+	return ObjectMeta{
+		Namespace:   namespace,
+		Name:        name,
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/configmap.go
+++ b/deps/github.com/YakLabs/k8s-client/configmap.go
@@ -1,0 +1,35 @@
+package client
+
+type (
+	ConfigMapInterface interface {
+		CreateConfigMap(namespace string, item *ConfigMap) (*ConfigMap, error)
+		GetConfigMap(namespace, name string) (result *ConfigMap, err error)
+		ListConfigMaps(namespace string, opts *ListOptions) (*ConfigMapList, error)
+		DeleteConfigMap(namespace, name string) error
+		UpdateConfigMap(namespace string, item *ConfigMap) (*ConfigMap, error)
+	}
+
+	ConfigMapType string
+
+	ConfigMap struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+		Data       map[string][]byte `json:"data,omitempty"`
+	}
+
+	ConfigMapList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		Items []ConfigMap `json:"items"`
+	}
+)
+
+// NewConfigMap creates a new ConfigMap struct
+func NewConfigMap(namespace, name string) *ConfigMap {
+	return &ConfigMap{
+		TypeMeta:   NewTypeMeta("ConfigMap", "v1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Data:       make(map[string][]byte),
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/daemonset.go
+++ b/deps/github.com/YakLabs/k8s-client/daemonset.go
@@ -1,0 +1,65 @@
+package client
+
+type (
+	// DaemonSetInterface has methods to work with DaemonSet resources.
+	DaemonSetInterface interface {
+		CreateDaemonSet(namespace string, item *DaemonSet) (*DaemonSet, error)
+		GetDaemonSet(namespace, name string) (result *DaemonSet, err error)
+		ListDaemonSets(namespace string, opts *ListOptions) (*DaemonSetList, error)
+		DeleteDaemonSet(namespace, name string) error
+		UpdateDaemonSet(namespace string, item *DaemonSet) (*DaemonSet, error)
+	}
+
+	// DaemonSet represents the configuration of a daemon set.
+	DaemonSet struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// Specification of the desired behavior of the DaemonSet.
+		Spec *DaemonSetSpec `json:"spec,omitempty"`
+
+		// Most recently observed status of the DaemonSet.
+		Status *DaemonSetStatus `json:"status,omitempty"`
+	}
+
+	// DaemonSetSpec is the specification of a daemon set.
+	DaemonSetSpec struct {
+		// Selector is a label query over pods that are managed by the daemon set.
+		// Must match in order to be controlled. If empty, defaulted to labels on Pod template.
+		Selector *LabelSelector `json:"selector,omitempty"`
+
+		// Template is the object that describes the pod that will be created.
+		// The DaemonSet will create exactly one copy of this pod on every node that matches the template’s
+		// node selector (or on every node if no node selector is specified).
+		Template PodTemplateSpec `json:"template"`
+	}
+
+	// DaemonSetStatus represents the current status of a daemon set.
+	DaemonSetStatus struct {
+		// CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod.
+		CurrentNumberScheduled int32 `json:"currentNumberScheduled"`
+		// NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod.
+		NumberMisscheduled int32 `json:"numberMisscheduled"`
+		// DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod).
+		DesiredNumberScheduled int32 `json:"desiredNumberScheduled"`
+		// NumberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
+		NumberReady int32 `json:"numberReady"`
+	}
+
+	DaemonSetList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		// Items is the list of daemonsets.
+		Items []DaemonSet `json:"items"`
+	}
+)
+
+// NewDaemonSet creates a new DaemonSet struct
+func NewDaemonSet(namespace, name string) *DaemonSet {
+	return &DaemonSet{
+		TypeMeta:   NewTypeMeta("DaemonSet", "extensions/v1beta1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Spec:       &DaemonSetSpec{},
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/deployment.go
+++ b/deps/github.com/YakLabs/k8s-client/deployment.go
@@ -1,0 +1,163 @@
+package client
+
+import "github.com/YakLabs/k8s-client/intstr"
+
+const (
+	// Kill all existing pods before creating new ones.
+	RecreateDeploymentStrategyType DeploymentStrategyType = "Recreate"
+
+	// Replace the old RCs by new one using rolling update i.e gradually scale down the old RCs and scale up the new one.
+	RollingUpdateDeploymentStrategyType DeploymentStrategyType = "RollingUpdate"
+)
+
+type (
+	// DeploymentInterface has methods to work with Deployment resources.
+	DeploymentInterface interface {
+		CreateDeployment(namespace string, item *Deployment) (*Deployment, error)
+		GetDeployment(namespace, name string) (result *Deployment, err error)
+		ListDeployments(namespace string, opts *ListOptions) (*DeploymentList, error)
+		DeleteDeployment(namespace, name string) error
+		UpdateDeployment(namespace string, item *Deployment) (*Deployment, error)
+	}
+
+	Deployment struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// Specification of the desired behavior of the Deployment.
+		Spec *DeploymentSpec `json:"spec,omitempty"`
+
+		// Most recently observed status of the Deployment.
+		Status *DeploymentStatus `json:"status,omitempty"`
+	}
+
+	// DeploymentSpec is the specification of the desired behavior of the Deployment.
+	DeploymentSpec struct {
+		// Number of desired pods. This is a pointer to distinguish between explicit
+		// zero and not specified. Defaults to 1.
+		Replicas int `json:"replicas,omitempty"`
+
+		// Label selector for pods. Existing ReplicaSets whose pods are
+		// selected by this will be the ones affected by this deployment.
+		Selector *LabelSelector `json:"selector,omitempty"`
+
+		// Template describes the pods that will be created.
+		Template PodTemplateSpec `json:"template"`
+
+		// The deployment strategy to use to replace existing pods with new ones.
+		Strategy *DeploymentStrategy `json:"strategy,omitempty"`
+
+		// Minimum number of seconds for which a newly created pod should be ready
+		// without any of its container crashing, for it to be considered available.
+		// Defaults to 0 (pod will be considered available as soon as it is ready)
+		MinReadySeconds int `json:"minReadySeconds,omitempty"`
+
+		// The number of old ReplicaSets to retain to allow rollback.
+		// This is a pointer to distinguish between explicit zero and not specified.
+		RevisionHistoryLimit *int `json:"revisionHistoryLimit,omitempty"`
+
+		// Indicates that the deployment is paused and will not be processed by the
+		// deployment controller.
+		Paused bool `json:"paused,omitempty"`
+		// The config this deployment is rolling back to. Will be cleared after rollback is done.
+		RollbackTo *RollbackConfig `json:"rollbackTo,omitempty"`
+	}
+
+	DeploymentStrategy struct {
+		// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+		Type DeploymentStrategyType `json:"type,omitempty"`
+
+		// Rolling update config params. Present only if DeploymentStrategyType =
+		// RollingUpdate.
+		//---
+		// TODO: Update this to follow our convention for oneOf, whatever we decide it
+		// to be.
+		RollingUpdate *RollingUpdateDeployment `json:"rollingUpdate,omitempty"`
+	}
+
+	DeploymentStrategyType string
+
+	// Spec to control the desired behavior of rolling update.
+	RollingUpdateDeployment struct {
+		// The maximum number of pods that can be unavailable during the update.
+		// Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
+		// Absolute number is calculated from percentage by rounding up.
+		// This can not be 0 if MaxSurge is 0.
+		// By default, a fixed value of 1 is used.
+		// Example: when this is set to 30%, the old RC can be scaled down by 30%
+		// immediately when the rolling update starts. Once new pods are ready, old RC
+		// can be scaled down further, followed by scaling up the new RC, ensuring
+		// that at least 70% of original number of pods are available at all times
+		// during the update.
+		MaxUnavailable intstr.IntOrString `json:"maxUnavailable,omitempty"`
+
+		// The maximum number of pods that can be scheduled above the original number of
+		// pods.
+		// Value can be an absolute number (ex: 5) or a percentage of total pods at
+		// the start of the update (ex: 10%). This can not be 0 if MaxUnavailable is 0.
+		// Absolute number is calculated from percentage by rounding up.
+		// By default, a value of 1 is used.
+		// Example: when this is set to 30%, the new RC can be scaled up by 30%
+		// immediately when the rolling update starts. Once old pods have been killed,
+		// new RC can be scaled up further, ensuring that total number of pods running
+		// at any time during the update is atmost 130% of original pods.
+		MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"`
+	}
+
+	RollbackConfig struct {
+		// The revision to rollback to. If set to 0, rollbck to the last revision.
+		Revision int64 `json:"revision,omitempty"`
+	}
+
+	// PodTemplateSpec describes the data a pod should have when created from a template
+	PodTemplateSpec struct {
+		// Metadata of the pods created from this template.
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// Spec defines the behavior of a pod.
+		Spec *PodSpec `json:"spec,omitempty"`
+	}
+
+	// DeploymentStatus is the most recently observed status of the Deployment.
+	DeploymentStatus struct {
+		// The generation observed by the deployment controller.
+		ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+		// Total number of non-terminated pods targeted by this deployment (their labels match the selector).
+		Replicas int `json:"replicas,omitempty"`
+
+		// Total number of non-terminated pods targeted by this deployment that have the desired template spec.
+		UpdatedReplicas int `json:"updatedReplicas,omitempty"`
+
+		// Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
+		AvailableReplicas int `json:"availableReplicas,omitempty"`
+
+		// Total number of unavailable pods targeted by this deployment.
+		UnavailableReplicas int `json:"unavailableReplicas,omitempty"`
+	}
+
+	DeploymentList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		// Items is the list of deployments.
+		Items []Deployment `json:"items"`
+	}
+)
+
+// NewDeployment creates a new Deployment struct
+func NewDeployment(namespace, name string) *Deployment {
+	return &Deployment{
+		TypeMeta:   NewTypeMeta("Deployment", "extensions/v1beta1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Spec:       &DeploymentSpec{},
+	}
+}
+
+// NewPodTemplateSpec creates a new PodTemplateSpec struct
+func NewPodTemplateSpec(namespace, name string) *PodTemplateSpec {
+	return &PodTemplateSpec{
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Spec:       &PodSpec{},
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/doc.go
+++ b/deps/github.com/YakLabs/k8s-client/doc.go
@@ -1,0 +1,2 @@
+// Package client provides a simple Kubernetes client
+package client

--- a/deps/github.com/YakLabs/k8s-client/errors.go
+++ b/deps/github.com/YakLabs/k8s-client/errors.go
@@ -1,0 +1,9 @@
+package client
+
+import "github.com/pkg/errors"
+
+// IsNotFoundError can be used to check if the error was a not found error.
+func IsNotFoundError(err error) bool {
+	s, ok := errors.Cause(err).(*Status)
+	return ok && s.Code == 404
+}

--- a/deps/github.com/YakLabs/k8s-client/horizontalpodautoscaler.go
+++ b/deps/github.com/YakLabs/k8s-client/horizontalpodautoscaler.go
@@ -1,0 +1,85 @@
+package client
+
+type (
+	HorizontalPodAutoscalerInterface interface {
+		CreateHorizontalPodAutoscaler(namespace string, item *HorizontalPodAutoscaler) (*HorizontalPodAutoscaler, error)
+		GetHorizontalPodAutoscaler(namespace, name string) (result *HorizontalPodAutoscaler, err error)
+		ListHorizontalPodAutoscalers(namespace string, opts *ListOptions) (*HorizontalPodAutoscalerList, error)
+		DeleteHorizontalPodAutoscaler(namespace, name string) error
+		UpdateHorizontalPodAutoscaler(namespace string, item *HorizontalPodAutoscaler) (*HorizontalPodAutoscaler, error)
+	}
+
+	// list of horizontal pod autoscaler objects.
+	HorizontalPodAutoscalerList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		// list of horizontal pod autoscaler objects.
+		Items []HorizontalPodAutoscaler `json:"items"`
+	}
+
+	// configuration of a horizontal pod autoscaler.
+	HorizontalPodAutoscaler struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// behaviour of autoscaler. More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#spec-and-status.
+		Spec *HorizontalPodAutoscalerSpec `json:"spec,omitempty"`
+
+		// current information about the autoscaler.
+		Status *HorizontalPodAutoscalerStatus `json:"status,omitempty"`
+	}
+
+	// current status of a horizontal pod autoscaler
+	HorizontalPodAutoscalerStatus struct {
+		// most recent generation observed by this autoscaler.
+		ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
+
+		// last time the HorizontalPodAutoscaler scaled the number of pods;
+		// used by the autoscaler to control how often the number of pods is changed.
+		LastScaleTime *Time `json:"lastScaleTime,omitempty"`
+
+		// current number of replicas of pods managed by this autoscaler.
+		CurrentReplicas int32 `json:"currentReplicas"`
+
+		// desired number of replicas of pods managed by this autoscaler.
+		DesiredReplicas int32 `json:"desiredReplicas"`
+
+		// current average CPU utilization over all pods, represented as a percentage of requested CPU,
+		// e.g. 70 means that an average pod is using now 70% of its requested CPU.
+		CurrentCPUUtilizationPercentage *int32 `json:"currentCPUUtilizationPercentage,omitempty"`
+	}
+
+	// specification of a horizontal pod autoscaler.
+	HorizontalPodAutoscalerSpec struct {
+		// reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption
+		// and will set the desired number of pods by using its Scale subresource.
+		ScaleTargetRef CrossVersionObjectReference `json:"scaleTargetRef"`
+		// lower limit for the number of pods that can be set by the autoscaler, default 1.
+		MinReplicas *int32 `json:"minReplicas,omitempty"`
+		// upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinReplicas.
+		MaxReplicas int32 `json:"maxReplicas"`
+		// target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
+		// if not specified the default autoscaling policy will be used.
+		TargetCPUUtilizationPercentage *int32 `json:"targetCPUUtilizationPercentage,omitempty"`
+	}
+
+	// CrossVersionObjectReference contains enough information to let you identify the referred resource.
+	CrossVersionObjectReference struct {
+		// Kind of the referent; More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds"
+		Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
+		// Name of the referent; More info: http://releases.k8s.io/release-1.3/docs/user-guide/identifiers.md#names
+		Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
+		// API version of the referent
+		APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,3,opt,name=apiVersion"`
+	}
+)
+
+// NewHorizontalPodAutoscaler creates a new HorizontalPodAutoscaler struct
+func NewHorizontalPodAutoscaler(namespace, name string) *HorizontalPodAutoscaler {
+	return &HorizontalPodAutoscaler{
+		TypeMeta:   NewTypeMeta("HorizontalPodAutoscaler", "autoscaling"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Spec:       &HorizontalPodAutoscalerSpec{},
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/http/README.md
+++ b/deps/github.com/YakLabs/k8s-client/http/README.md
@@ -1,0 +1,17 @@
+k8s-client HTTP provider[![GoDoc](https://godoc.org/github.com/YakLabs/k8s-client/http?status.svg)](https://godoc.org/github.com/YakLabs/k8s-client/http)
+=================
+
+This provides a concrete, HTTP client for [k8s-client](https://godoc.org/github.com/YakLabs/k8s-client).
+
+Use this client when you actually want to contact a Kubernetes Server
+
+## License
+
+[Apache 2 License](../LICENSE)
+
+## Usage
+
+See
+[![GoDoc](https://godoc.org/github.com/YakLabs/k8s-client/http?status.svg)](https://godoc.org/github.com/YakLabs/k8s-client/http)
+for documentation.
+

--- a/deps/github.com/YakLabs/k8s-client/http/client.go
+++ b/deps/github.com/YakLabs/k8s-client/http/client.go
@@ -1,0 +1,342 @@
+package http
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	http "net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+//go:generate ./make-type HorizontalPodAutoscaler autoscaling/v1
+//go:generate ./make-type Secret v1
+//go:generate ./make-type DaemonSet extensions/v1beta1
+//go:generate ./make-type Deployment extensions/v1beta1
+//go:generate ./make-type Ingress extensions/v1beta1 es
+//go:generate ./make-type Job batch/v1
+//go:generate ./make-type Pod v1
+//go:generate ./make-type ConfigMap v1
+//go:generate ./make-type ReplicaSet extensions/v1beta1
+//go:generate ./make-type Service v1
+//go:generate ./make-type ServiceAccount v1
+
+const (
+	tokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	caFile    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)
+
+type (
+	// Client is an http client for kubernetes
+	Client struct {
+		username           string
+		password           string
+		token              string
+		authHeader         string
+		server             string
+		certPool           *x509.CertPool
+		clientCert         []byte
+		clientKey          []byte
+		insecureSkipVerify bool
+		client             *http.Client
+	}
+
+	// OptionsFunc is a function passed to new for setting options on a new client.
+	OptionsFunc func(*Client) error
+)
+
+// New creates a new client.
+func New(options ...OptionsFunc) (*Client, error) {
+	c := &Client{}
+	for _, f := range options {
+		if err := f(c); err != nil {
+			return nil, err
+		}
+	}
+
+	if c.client == nil {
+		// TODO: allow passing in CA to use.
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: c.insecureSkipVerify,
+			},
+		}
+
+		if c.certPool != nil {
+			tr.TLSClientConfig.RootCAs = c.certPool
+		}
+
+		if c.clientCert != nil && c.clientKey != nil {
+			cert, err := tls.X509KeyPair(c.clientCert, c.clientKey)
+			if err != nil {
+				return nil, errors.Wrap(err, "X509KeyPair failed")
+			}
+			tr.TLSClientConfig.Certificates = []tls.Certificate{cert}
+			tr.TLSClientConfig.BuildNameToCertificate()
+		}
+
+		c.client = &http.Client{
+			Transport: tr,
+		}
+	}
+
+	if c.token != "" {
+		c.authHeader = "Bearer " + c.token
+	} else {
+		if c.username != "" {
+			c.authHeader = base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
+		}
+	}
+
+	return c, nil
+}
+
+// NewInCluster creates a cluster suitable for use within the kubernetes cluster.
+func NewInCluster() (*Client, error) {
+	host := os.Getenv("KUBERNETES_SERVICE_HOST")
+	if host == "" {
+		return nil, errors.New("KUBERNETES_SERVICE_HOST is not set")
+	}
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if port == "" {
+		return nil, errors.New("KUBERNETES_SERVICE_PORT is not set")
+	}
+	server := fmt.Sprintf("https://%s:%s", host, port)
+
+	token, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read token file: "+tokenFile)
+	}
+
+	return New(SetToken(string(token)), SetServer(server), SetCAFromFile(caFile))
+}
+
+// SetUsername sets the username to be used for authentication.
+func SetUsername(username string) func(*Client) error {
+	return func(c *Client) error {
+		c.username = username
+		return nil
+	}
+}
+
+// SetPassword sets the password to be used for authentication.
+func SetPassword(password string) func(*Client) error {
+	return func(c *Client) error {
+		c.password = password
+		return nil
+	}
+}
+
+// SetToken sets the token to be used for authentication. If this is set, it
+// takes precedence.
+func SetToken(token string) func(*Client) error {
+	return func(c *Client) error {
+		c.token = token
+		return nil
+	}
+}
+
+// SetServer sets the target API server
+func SetServer(server string) func(*Client) error {
+	return func(c *Client) error {
+		// make sure its valid
+		if _, err := url.Parse(server); err != nil {
+			return errors.Wrap(err, "failed to parse server")
+		}
+		c.server = server
+		return nil
+	}
+}
+
+// SetClient allows the caller to specify a custom http.Client to use
+func SetClient(client *http.Client) func(*Client) error {
+	return func(c *Client) error {
+		c.client = client
+		return nil
+	}
+}
+
+// SetCA sets a CA to verify the servers certificate
+func SetCA(cert []byte) func(*Client) error {
+	return func(c *Client) error {
+		c.certPool = x509.NewCertPool()
+		if ok := c.certPool.AppendCertsFromPEM(cert); !ok {
+			return errors.New("AppendCertsFromPEM failed")
+		}
+		return nil
+	}
+}
+
+// SetCA sets a CA to verify the servers certificate from a file
+func SetCAFromFile(path string) func(*Client) error {
+	return func(c *Client) error {
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return SetCA(data)(c)
+	}
+}
+
+// SetClientCert sets the certificate to be used for authentication.
+func SetClientCert(cert []byte) func(*Client) error {
+	return func(c *Client) error {
+		c.clientCert = cert
+		return nil
+	}
+}
+
+// SetClientCertFromFile sets the certificate to be used for authentication from a file.
+func SetClientCertFromFile(path string) func(*Client) error {
+	return func(c *Client) error {
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return SetClientCert(data)(c)
+	}
+}
+
+// SetClientKey sets the key to be used for authentication.
+func SetClientKey(key []byte) func(*Client) error {
+	return func(c *Client) error {
+		c.clientKey = key
+		return nil
+	}
+}
+
+// SetClientKeyFromFile sets the key to be used for authentication from a file.
+func SetClientKeyFromFile(path string) func(*Client) error {
+	return func(c *Client) error {
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return SetClientKey(data)(c)
+	}
+}
+
+// SetInsecureSkipVerify allows the caller to skip verification of the servers cert
+func SetInsecureSkipVerify(skip bool) func(*Client) error {
+	return func(c *Client) error {
+		c.insecureSkipVerify = skip
+		return nil
+	}
+}
+func (c *Client) newRequest(method, path string, v interface{}) (*http.Request, error) {
+	if v != nil {
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequest(method, c.server+path, bytes.NewBuffer(data))
+		if err != nil {
+			return nil, err
+		}
+		if c.authHeader != "" {
+			req.Header.Add("Authorization", c.authHeader)
+		}
+		return req, nil
+	}
+	// weirdness with passing nil interface, so just copy/paste
+	req, err := http.NewRequest(method, c.server+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", c.authHeader)
+	return req, nil
+}
+
+func readStatus(body io.Reader) (*k8s.Status, error) {
+	data, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read response body")
+	}
+	var out k8s.Status
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, errors.Wrap(err, "unable to unmarshal status")
+	}
+	return &out, nil
+}
+
+func (c *Client) do(method, path string, in interface{}, out interface{}, codes ...int) (int, error) {
+	req, err := c.newRequest(method, path, in)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+
+	// make errcheck happy
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if len(codes) == 0 {
+		codes = []int{
+			200,
+		}
+	}
+
+	found := false
+	for _, i := range codes {
+		if i == resp.StatusCode {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		status, err := readStatus(resp.Body)
+		if err != nil {
+			return resp.StatusCode, errors.Wrapf(err, "unable to read status: %d", resp.StatusCode)
+		}
+		return resp.StatusCode, status
+	}
+
+	if out != nil {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return resp.StatusCode, errors.Wrap(err, "failed to read response body")
+		}
+		if err := json.Unmarshal(body, out); err != nil {
+			return resp.StatusCode, err
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+func listOptionsQuery(opts *k8s.ListOptions) string {
+	if opts == nil {
+		return ""
+	}
+	val := url.Values{}
+	if opts.LabelSelector.MatchLabels != nil && len(opts.LabelSelector.MatchLabels) > 0 {
+		var labels []string
+		for k, v := range opts.LabelSelector.MatchLabels {
+			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+		}
+		val.Set("labelSelector", strings.Join(labels, ","))
+	}
+	if opts.FieldSelector != nil && len(opts.FieldSelector) > 0 {
+		var fields []string
+		for k, v := range opts.FieldSelector {
+			fields = append(fields, fmt.Sprintf("%s=%s", k, v))
+		}
+		val.Set("fieldSelector", strings.Join(fields, ","))
+	}
+
+	return val.Encode()
+}

--- a/deps/github.com/YakLabs/k8s-client/http/client_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/client_test.go
@@ -1,0 +1,39 @@
+package http_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/require"
+)
+
+// create a test client based on env variables.
+func testClient(t *testing.T) *http.Client {
+	server := os.Getenv("K8S_SERVER")
+
+	if server == "" {
+		server = "http://127.0.0.1:8001"
+	}
+
+	opts := []http.OptionsFunc{
+		http.SetServer(server),
+	}
+
+	if caFile := os.Getenv("K8S_CAFILE"); caFile != "" {
+		opts = append(opts, http.SetCAFromFile(caFile))
+	}
+
+	if clientCert := os.Getenv("K8S_CLIENTCERT"); clientCert != "" {
+		opts = append(opts, http.SetClientCertFromFile(clientCert))
+	}
+
+	if clientKey := os.Getenv("K8S_CLIENTKEY"); clientKey != "" {
+		opts = append(opts, http.SetClientKeyFromFile(clientKey))
+	}
+
+	c, err := http.New(opts...)
+	require.Nil(t, err)
+
+	return c
+}

--- a/deps/github.com/YakLabs/k8s-client/http/configmap.go
+++ b/deps/github.com/YakLabs/k8s-client/http/configmap.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func configmapGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/api/v1/namespaces/" + namespace + "/configmaps"
+	}
+	return "/api/v1/namespaces/" + namespace + "/configmaps/" + name
+}
+
+// GetConfigMap fetches a single ConfigMap
+func (c *Client) GetConfigMap(namespace, name string) (*k8s.ConfigMap, error) {
+	var out k8s.ConfigMap
+	_, err := c.do("GET", configmapGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get ConfigMap")
+	}
+	return &out, nil
+}
+
+// CreateConfigMap creates a new ConfigMap. This will fail if it already exists.
+func (c *Client) CreateConfigMap(namespace string, item *k8s.ConfigMap) (*k8s.ConfigMap, error) {
+	item.TypeMeta.Kind = "ConfigMap"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.ConfigMap
+	_, err := c.do("POST", configmapGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create ConfigMap")
+	}
+	return &out, nil
+}
+
+// ListConfigMaps lists all ConfigMaps in a namespace
+func (c *Client) ListConfigMaps(namespace string, opts *k8s.ListOptions) (*k8s.ConfigMapList, error) {
+	var out k8s.ConfigMapList
+	_, err := c.do("GET", configmapGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list ConfigMaps")
+	}
+	return &out, nil
+}
+
+// DeleteConfigMap deletes a single ConfigMap. It will error if the ConfigMap does not exist.
+func (c *Client) DeleteConfigMap(namespace, name string) error {
+	_, err := c.do("DELETE", configmapGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete ConfigMap")
+}
+
+// UpdateConfigMap will update in place a single ConfigMap. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateConfigMap(namespace string, item *k8s.ConfigMap) (*k8s.ConfigMap, error) {
+	item.TypeMeta.Kind = "ConfigMap"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.ConfigMap
+	_, err := c.do("PUT", configmapGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update ConfigMap")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/configmap_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/configmap_test.go
@@ -1,0 +1,51 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigMapList(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		list, err := c.ListConfigMaps(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+	})
+}
+
+func TestConfigMapCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		in := &client.ConfigMap{
+			ObjectMeta: client.ObjectMeta{
+				Name: "test-config",
+			},
+		}
+		out, err := c.CreateConfigMap(n.Name, in)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		list, err := c.ListConfigMaps(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+		assert.True(t, len(list.Items) > 0, "should not be empty")
+
+		out, err = c.GetConfigMap(n.Name, in.Name)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		in.Data = map[string][]byte{
+			"foo": []byte("value"),
+		}
+
+		out, err = c.UpdateConfigMap(n.Name, in)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+		assert.True(t, len(out.Data) > 0, "should not be empty")
+
+		err = c.DeleteConfigMap(n.Name, in.Name)
+		assert.Nil(t, err)
+	})
+}

--- a/deps/github.com/YakLabs/k8s-client/http/daemonset.go
+++ b/deps/github.com/YakLabs/k8s-client/http/daemonset.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func daemonsetGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/apis/extensions/v1beta1/namespaces/" + namespace + "/daemonsets"
+	}
+	return "/apis/extensions/v1beta1/namespaces/" + namespace + "/daemonsets/" + name
+}
+
+// GetDaemonSet fetches a single DaemonSet
+func (c *Client) GetDaemonSet(namespace, name string) (*k8s.DaemonSet, error) {
+	var out k8s.DaemonSet
+	_, err := c.do("GET", daemonsetGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get DaemonSet")
+	}
+	return &out, nil
+}
+
+// CreateDaemonSet creates a new DaemonSet. This will fail if it already exists.
+func (c *Client) CreateDaemonSet(namespace string, item *k8s.DaemonSet) (*k8s.DaemonSet, error) {
+	item.TypeMeta.Kind = "DaemonSet"
+	item.TypeMeta.APIVersion = "extensions/v1beta1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.DaemonSet
+	_, err := c.do("POST", daemonsetGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create DaemonSet")
+	}
+	return &out, nil
+}
+
+// ListDaemonSets lists all DaemonSets in a namespace
+func (c *Client) ListDaemonSets(namespace string, opts *k8s.ListOptions) (*k8s.DaemonSetList, error) {
+	var out k8s.DaemonSetList
+	_, err := c.do("GET", daemonsetGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list DaemonSets")
+	}
+	return &out, nil
+}
+
+// DeleteDaemonSet deletes a single DaemonSet. It will error if the DaemonSet does not exist.
+func (c *Client) DeleteDaemonSet(namespace, name string) error {
+	_, err := c.do("DELETE", daemonsetGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete DaemonSet")
+}
+
+// UpdateDaemonSet will update in place a single DaemonSet. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateDaemonSet(namespace string, item *k8s.DaemonSet) (*k8s.DaemonSet, error) {
+	item.TypeMeta.Kind = "DaemonSet"
+	item.TypeMeta.APIVersion = "extensions/v1beta1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.DaemonSet
+	_, err := c.do("PUT", daemonsetGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update DaemonSet")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/deployment.go
+++ b/deps/github.com/YakLabs/k8s-client/http/deployment.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func deploymentGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/apis/extensions/v1beta1/namespaces/" + namespace + "/deployments"
+	}
+	return "/apis/extensions/v1beta1/namespaces/" + namespace + "/deployments/" + name
+}
+
+// GetDeployment fetches a single Deployment
+func (c *Client) GetDeployment(namespace, name string) (*k8s.Deployment, error) {
+	var out k8s.Deployment
+	_, err := c.do("GET", deploymentGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get Deployment")
+	}
+	return &out, nil
+}
+
+// CreateDeployment creates a new Deployment. This will fail if it already exists.
+func (c *Client) CreateDeployment(namespace string, item *k8s.Deployment) (*k8s.Deployment, error) {
+	item.TypeMeta.Kind = "Deployment"
+	item.TypeMeta.APIVersion = "extensions/v1beta1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Deployment
+	_, err := c.do("POST", deploymentGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Deployment")
+	}
+	return &out, nil
+}
+
+// ListDeployments lists all Deployments in a namespace
+func (c *Client) ListDeployments(namespace string, opts *k8s.ListOptions) (*k8s.DeploymentList, error) {
+	var out k8s.DeploymentList
+	_, err := c.do("GET", deploymentGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list Deployments")
+	}
+	return &out, nil
+}
+
+// DeleteDeployment deletes a single Deployment. It will error if the Deployment does not exist.
+func (c *Client) DeleteDeployment(namespace, name string) error {
+	_, err := c.do("DELETE", deploymentGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete Deployment")
+}
+
+// UpdateDeployment will update in place a single Deployment. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateDeployment(namespace string, item *k8s.Deployment) (*k8s.Deployment, error) {
+	item.TypeMeta.Kind = "Deployment"
+	item.TypeMeta.APIVersion = "extensions/v1beta1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Deployment
+	_, err := c.do("PUT", deploymentGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update Deployment")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/deployment_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/deployment_test.go
@@ -1,0 +1,44 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeploymentList(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		list, err := c.ListDeployments(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+	})
+}
+
+func TestDeploymentCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		/*
+			in := &client.Deployment{
+				ObjectMeta: client.ObjectMeta{
+					Name: "test-deployment",
+				},
+			}
+			out, err := c.CreateDeployment(n.Name, in)
+			assert.Nil(t, err)
+			assert.NotNil(t, out)
+
+			list, err := c.ListDeployments(n.Name, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, list)
+			assert.True(t, len(list.Items) > 0, "should not be empty")
+
+			out, err = c.GetDeployment(n.Name, in.Name)
+			assert.Nil(t, err)
+			assert.NotNil(t, out)
+
+			err = c.DeleteDeployment(n.Name, in.Name)
+			assert.Nil(t, err)
+		*/
+	})
+}

--- a/deps/github.com/YakLabs/k8s-client/http/doc.go
+++ b/deps/github.com/YakLabs/k8s-client/http/doc.go
@@ -1,0 +1,2 @@
+// Package http provides an HTTP client for kubernetes
+package http

--- a/deps/github.com/YakLabs/k8s-client/http/example_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/example_test.go
@@ -1,0 +1,61 @@
+package http_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/YakLabs/k8s-client/http"
+)
+
+func ExampleNew() {
+
+	// get server from environment
+	server := os.Getenv("K8S_SERVER")
+	if server == "" {
+		server = "http://127.0.0.1:8001"
+	}
+
+	opts := []http.OptionsFunc{
+		http.SetServer(server),
+	}
+
+	if caFile := os.Getenv("K8S_CAFILE"); caFile != "" {
+		opts = append(opts, http.SetCAFromFile(caFile))
+	}
+
+	if token := os.Getenv("K8S_TOKEN"); token != "" {
+		opts = append(opts, http.SetToken(token))
+	}
+
+	// create a new client using the options
+	c, err := http.New(opts...)
+
+	if err != nil {
+		// handle the error
+	}
+
+	// get a list of all the name spaces
+	list, err := c.ListNamespaces(nil)
+	if err != nil {
+		// handle the error
+	}
+
+	for _, v := range list.Items {
+		fmt.Println(v.Name)
+	}
+}
+
+func ExampleNewInCluster() {
+	// NewInCluster will use the environment and the service account files to create a new client
+	c, err := http.NewInCluster()
+
+	// get a list of all the name spaces
+	list, err := c.ListNamespaces(nil)
+	if err != nil {
+		// handle the error
+	}
+
+	for _, v := range list.Items {
+		fmt.Println(v.Name)
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/http/horizontalpodautoscaler.go
+++ b/deps/github.com/YakLabs/k8s-client/http/horizontalpodautoscaler.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func horizontalpodautoscalerGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/apis/autoscaling/v1/namespaces/" + namespace + "/horizontalpodautoscalers"
+	}
+	return "/apis/autoscaling/v1/namespaces/" + namespace + "/horizontalpodautoscalers/" + name
+}
+
+// GetHorizontalPodAutoscaler fetches a single HorizontalPodAutoscaler
+func (c *Client) GetHorizontalPodAutoscaler(namespace, name string) (*k8s.HorizontalPodAutoscaler, error) {
+	var out k8s.HorizontalPodAutoscaler
+	_, err := c.do("GET", horizontalpodautoscalerGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get HorizontalPodAutoscaler")
+	}
+	return &out, nil
+}
+
+// CreateHorizontalPodAutoscaler creates a new HorizontalPodAutoscaler. This will fail if it already exists.
+func (c *Client) CreateHorizontalPodAutoscaler(namespace string, item *k8s.HorizontalPodAutoscaler) (*k8s.HorizontalPodAutoscaler, error) {
+	item.TypeMeta.Kind = "HorizontalPodAutoscaler"
+	item.TypeMeta.APIVersion = "autoscaling/v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.HorizontalPodAutoscaler
+	_, err := c.do("POST", horizontalpodautoscalerGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create HorizontalPodAutoscaler")
+	}
+	return &out, nil
+}
+
+// ListHorizontalPodAutoscalers lists all HorizontalPodAutoscalers in a namespace
+func (c *Client) ListHorizontalPodAutoscalers(namespace string, opts *k8s.ListOptions) (*k8s.HorizontalPodAutoscalerList, error) {
+	var out k8s.HorizontalPodAutoscalerList
+	_, err := c.do("GET", horizontalpodautoscalerGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list HorizontalPodAutoscalers")
+	}
+	return &out, nil
+}
+
+// DeleteHorizontalPodAutoscaler deletes a single HorizontalPodAutoscaler. It will error if the HorizontalPodAutoscaler does not exist.
+func (c *Client) DeleteHorizontalPodAutoscaler(namespace, name string) error {
+	_, err := c.do("DELETE", horizontalpodautoscalerGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete HorizontalPodAutoscaler")
+}
+
+// UpdateHorizontalPodAutoscaler will update in place a single HorizontalPodAutoscaler. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateHorizontalPodAutoscaler(namespace string, item *k8s.HorizontalPodAutoscaler) (*k8s.HorizontalPodAutoscaler, error) {
+	item.TypeMeta.Kind = "HorizontalPodAutoscaler"
+	item.TypeMeta.APIVersion = "autoscaling/v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.HorizontalPodAutoscaler
+	_, err := c.do("PUT", horizontalpodautoscalerGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update HorizontalPodAutoscaler")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/horizontalpodautoscaler_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/horizontalpodautoscaler_test.go
@@ -1,0 +1,46 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHorizontalPodAutoscalerList(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		list, err := c.ListHorizontalPodAutoscalers(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+	})
+}
+
+func TestHorizontalPodAutoscalerCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		in := client.NewHorizontalPodAutoscaler(n.Name, "test-hpa")
+		in.Spec.MaxReplicas = 3
+		in.Spec.ScaleTargetRef = client.CrossVersionObjectReference{
+			Kind:       "ReplicationController",
+			Name:       "test",
+			APIVersion: "v1",
+		}
+
+		out, err := c.CreateHorizontalPodAutoscaler(n.Name, in)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		list, err := c.ListHorizontalPodAutoscalers(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+		assert.True(t, len(list.Items) > 0, "should not be empty")
+
+		out, err = c.GetHorizontalPodAutoscaler(n.Name, in.Name)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		err = c.DeleteHorizontalPodAutoscaler(n.Name, in.Name)
+		assert.Nil(t, err)
+
+	})
+}

--- a/deps/github.com/YakLabs/k8s-client/http/ingress.go
+++ b/deps/github.com/YakLabs/k8s-client/http/ingress.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func ingressGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/apis/extensions/v1beta1/namespaces/" + namespace + "/ingresses"
+	}
+	return "/apis/extensions/v1beta1/namespaces/" + namespace + "/ingresses/" + name
+}
+
+// GetIngress fetches a single Ingress
+func (c *Client) GetIngress(namespace, name string) (*k8s.Ingress, error) {
+	var out k8s.Ingress
+	_, err := c.do("GET", ingressGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get Ingress")
+	}
+	return &out, nil
+}
+
+// CreateIngress creates a new Ingress. This will fail if it already exists.
+func (c *Client) CreateIngress(namespace string, item *k8s.Ingress) (*k8s.Ingress, error) {
+	item.TypeMeta.Kind = "Ingress"
+	item.TypeMeta.APIVersion = "extensions/v1beta1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Ingress
+	_, err := c.do("POST", ingressGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Ingress")
+	}
+	return &out, nil
+}
+
+// ListIngresses lists all Ingresss in a namespace
+func (c *Client) ListIngresses(namespace string, opts *k8s.ListOptions) (*k8s.IngressList, error) {
+	var out k8s.IngressList
+	_, err := c.do("GET", ingressGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list Ingresss")
+	}
+	return &out, nil
+}
+
+// DeleteIngress deletes a single Ingress. It will error if the Ingress does not exist.
+func (c *Client) DeleteIngress(namespace, name string) error {
+	_, err := c.do("DELETE", ingressGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete Ingress")
+}
+
+// UpdateIngress will update in place a single Ingress. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateIngress(namespace string, item *k8s.Ingress) (*k8s.Ingress, error) {
+	item.TypeMeta.Kind = "Ingress"
+	item.TypeMeta.APIVersion = "extensions/v1beta1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Ingress
+	_, err := c.do("PUT", ingressGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update Ingress")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/job.go
+++ b/deps/github.com/YakLabs/k8s-client/http/job.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func jobGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/apis/batch/v1/namespaces/" + namespace + "/jobs"
+	}
+	return "/apis/batch/v1/namespaces/" + namespace + "/jobs/" + name
+}
+
+// GetJob fetches a single Job
+func (c *Client) GetJob(namespace, name string) (*k8s.Job, error) {
+	var out k8s.Job
+	_, err := c.do("GET", jobGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get Job")
+	}
+	return &out, nil
+}
+
+// CreateJob creates a new Job. This will fail if it already exists.
+func (c *Client) CreateJob(namespace string, item *k8s.Job) (*k8s.Job, error) {
+	item.TypeMeta.Kind = "Job"
+	item.TypeMeta.APIVersion = "batch/v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Job
+	_, err := c.do("POST", jobGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Job")
+	}
+	return &out, nil
+}
+
+// ListJobs lists all Jobs in a namespace
+func (c *Client) ListJobs(namespace string, opts *k8s.ListOptions) (*k8s.JobList, error) {
+	var out k8s.JobList
+	_, err := c.do("GET", jobGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list Jobs")
+	}
+	return &out, nil
+}
+
+// DeleteJob deletes a single Job. It will error if the Job does not exist.
+func (c *Client) DeleteJob(namespace, name string) error {
+	_, err := c.do("DELETE", jobGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete Job")
+}
+
+// UpdateJob will update in place a single Job. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateJob(namespace string, item *k8s.Job) (*k8s.Job, error) {
+	item.TypeMeta.Kind = "Job"
+	item.TypeMeta.APIVersion = "batch/v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Job
+	_, err := c.do("PUT", jobGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update Job")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/make-type
+++ b/deps/github.com/YakLabs/k8s-client/http/make-type
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+TYPE=$1
+APIPATH=`echo ${TYPE} | tr '[:upper:]' '[:lower:]'`
+
+APIVERSION=${2:-v1}
+
+APIPATHEXT=${3:-s}
+
+case ${APIVERSION} in
+    "extensions/v1beta1")
+        API=/apis/extensions/v1beta1
+        ;;
+    "v1")
+        API=/api/v1
+        ;;
+    "batch/v1")
+        API=/apis/batch/v1
+        ;;
+    "autoscaling/v1")
+        API=/apis/autoscaling/v1
+        ;;
+    *)
+        echo "unknown API"
+        exit -4
+        ;;
+esac
+
+cat <<EOF | gofmt > ${APIPATH}.go
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+
+func ${APIPATH}GeneratePath(namespace, name string) string {
+    if name == "" {
+        return "${API}/namespaces/"+namespace+"/${APIPATH}${APIPATHEXT}"
+    }
+    return "${API}/namespaces/"+namespace+"/${APIPATH}${APIPATHEXT}/"+name
+}
+
+// Get${TYPE} fetches a single ${TYPE}
+func (c *Client) Get${TYPE}(namespace, name string) (*k8s.${TYPE}, error) {
+	var out k8s.${TYPE}
+	_, err := c.do("GET", ${APIPATH}GeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get ${TYPE}")
+	}
+	return &out, nil
+}
+
+// Create${TYPE} creates a new ${TYPE}. This will fail if it already exists.
+func (c *Client) Create${TYPE}(namespace string, item *k8s.${TYPE}) (*k8s.${TYPE}, error) {
+	item.TypeMeta.Kind = "${TYPE}"
+	item.TypeMeta.APIVersion = "${APIVERSION}"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.${TYPE}
+	_, err := c.do("POST", ${APIPATH}GeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create ${TYPE}")
+	}
+	return &out, nil
+}
+
+// List${TYPE}${APIPATHEXT} lists all ${TYPE}s in a namespace
+func (c *Client) List${TYPE}${APIPATHEXT}(namespace string, opts *k8s.ListOptions) (*k8s.${TYPE}List, error) {
+	var out k8s.${TYPE}List
+	_, err := c.do("GET", ${APIPATH}GeneratePath(namespace, "") + "?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list ${TYPE}s")
+	}
+	return &out, nil
+}
+
+// Delete${TYPE} deletes a single ${TYPE}. It will error if the ${TYPE} does not exist.
+func (c *Client) Delete${TYPE}(namespace, name string) error {
+	_, err := c.do("DELETE", ${APIPATH}GeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete ${TYPE}")
+}
+
+// Update${TYPE} will update in place a single ${TYPE}. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) Update${TYPE}(namespace string, item *k8s.${TYPE}) (*k8s.${TYPE}, error) {
+	item.TypeMeta.Kind = "${TYPE}"
+	item.TypeMeta.APIVersion = "${APIVERSION}"
+    item.ObjectMeta.Namespace = namespace
+
+	var out k8s.${TYPE}
+	_, err := c.do("PUT", ${APIPATH}GeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update ${TYPE}")
+	}
+	return &out, nil
+}
+EOF

--- a/deps/github.com/YakLabs/k8s-client/http/namespace.go
+++ b/deps/github.com/YakLabs/k8s-client/http/namespace.go
@@ -1,0 +1,58 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+// GetNamespace gets a namespace
+func (c *Client) GetNamespace(name string) (*k8s.Namespace, error) {
+	var out k8s.Namespace
+	_, err := c.do("GET", "/api/v1/namespaces/"+name, nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get namespace")
+	}
+	return &out, nil
+}
+
+// CreateNamespace creates a new namespace. It will fail if the namespace already exists.
+func (c *Client) CreateNamespace(item *k8s.Namespace) (*k8s.Namespace, error) {
+	item.TypeMeta.Kind = "Namespace"
+	item.TypeMeta.APIVersion = "v1"
+
+	var out k8s.Namespace
+	_, err := c.do("POST", "/api/v1/namespaces", item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create namespace")
+	}
+	return &out, nil
+}
+
+// ListNamespaces list all namespaces, optionally filtering.
+func (c *Client) ListNamespaces(opts *k8s.ListOptions) (*k8s.NamespaceList, error) {
+	var out k8s.NamespaceList
+	_, err := c.do("GET", "/api/v1/namespaces?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list namespaces")
+	}
+	return &out, nil
+}
+
+// DeleteNamespace deletes a single namespace. It will error it it does not exist.
+func (c *Client) DeleteNamespace(name string) error {
+	_, err := c.do("DELETE", "/api/v1/namespaces/"+name, nil, nil)
+	return errors.Wrap(err, "failed to delete namespace")
+}
+
+// UpdateNamespace updates a namespace.
+func (c *Client) UpdateNamespace(item *k8s.Namespace) (*k8s.Namespace, error) {
+	item.TypeMeta.Kind = "Namespace"
+	item.TypeMeta.APIVersion = "v1"
+
+	var out k8s.Namespace
+	_, err := c.do("PUT", "/api/v1/namespaces/"+item.Name, item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update namespace")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/namespace_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/namespace_test.go
@@ -1,0 +1,69 @@
+package http_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//helper for using a test namespace
+func withTestNamespace(t *testing.T, f func(*testing.T, *http.Client, *client.Namespace)) {
+	c := testClient(t)
+
+	for {
+		// deletion is not immediate, so wait until its gone
+		_, err := c.GetNamespace("test123")
+		// should make sure this is a not found error, but it'll fail later
+		// if its something else
+		if err != nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	ns := client.Namespace{
+		ObjectMeta: client.ObjectMeta{
+			Name: "test123",
+		},
+	}
+	out, err := c.CreateNamespace(&ns)
+	require.Nil(t, err)
+	require.NotNil(t, out)
+
+	f(t, c, out)
+	err = c.DeleteNamespace("test123")
+	require.Nil(t, err)
+}
+
+func TestNamespaceGet(t *testing.T) {
+	c := testClient(t)
+	n, err := c.GetNamespace("default")
+	assert.Nil(t, err)
+	assert.NotNil(t, n)
+	assert.Equal(t, "default", n.Name, "name should be equal")
+}
+
+func TestNamespaceList(t *testing.T) {
+	c := testClient(t)
+	list, err := c.ListNamespaces(nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, list)
+	assert.True(t, len(list.Items) > 0, "list should not be empty")
+}
+
+func TestNamespaceCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		n.ObjectMeta.Labels = map[string]string{
+			"foo": "bar",
+		}
+		out, err := c.UpdateNamespace(n)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+		assert.NotNil(t, out.ObjectMeta.Labels)
+		assert.Equal(t, "bar", out.ObjectMeta.Labels["foo"], "labels should be equal")
+	})
+}

--- a/deps/github.com/YakLabs/k8s-client/http/node.go
+++ b/deps/github.com/YakLabs/k8s-client/http/node.go
@@ -1,0 +1,58 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+// GetNode gets a single node.
+func (c *Client) GetNode(name string) (*k8s.Node, error) {
+	var out k8s.Node
+	_, err := c.do("GET", "/api/v1/nodes/"+name, nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get node")
+	}
+	return &out, nil
+}
+
+// CreateNode creates a single node. It will fail if it already exists.
+func (c *Client) CreateNode(item *k8s.Node) (*k8s.Node, error) {
+	item.TypeMeta.Kind = "Node"
+	item.TypeMeta.APIVersion = "v1"
+
+	var out k8s.Node
+	_, err := c.do("POST", "/api/v1/nodes", item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create node")
+	}
+	return &out, nil
+}
+
+// ListNodes list all nodes, optionally filtering.
+func (c *Client) ListNodes(opts *k8s.ListOptions) (*k8s.NodeList, error) {
+	var out k8s.NodeList
+	_, err := c.do("GET", "/api/v1/nodes?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list nodes")
+	}
+	return &out, nil
+}
+
+// DeleteNode removes a single node.
+func (c *Client) DeleteNode(name string) error {
+	_, err := c.do("DELETE", "/api/v1/nodes/"+name, nil, nil)
+	return errors.Wrap(err, "failed to delete node")
+}
+
+// UpdateNode updates s sinle node.
+func (c *Client) UpdateNode(item *k8s.Node) (*k8s.Node, error) {
+	item.TypeMeta.Kind = "Node"
+	item.TypeMeta.APIVersion = "v1"
+
+	var out k8s.Node
+	_, err := c.do("PUT", "/api/v1/nodes/"+item.Name, item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update node")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/node_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/node_test.go
@@ -1,0 +1,27 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeList(t *testing.T) {
+	c := testClient(t)
+	list, err := c.ListNodes(nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, list)
+	assert.True(t, len(list.Items) > 0, "list should not be empty")
+}
+
+func TestNodeGet(t *testing.T) {
+	c := testClient(t)
+	list, err := c.ListNodes(nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, list)
+	assert.True(t, len(list.Items) > 0, "list should not be empty")
+
+	out, err := c.GetNode(list.Items[0].Name)
+	assert.Nil(t, err)
+	assert.NotNil(t, out)
+}

--- a/deps/github.com/YakLabs/k8s-client/http/pod.go
+++ b/deps/github.com/YakLabs/k8s-client/http/pod.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func podGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/api/v1/namespaces/" + namespace + "/pods"
+	}
+	return "/api/v1/namespaces/" + namespace + "/pods/" + name
+}
+
+// GetPod fetches a single Pod
+func (c *Client) GetPod(namespace, name string) (*k8s.Pod, error) {
+	var out k8s.Pod
+	_, err := c.do("GET", podGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get Pod")
+	}
+	return &out, nil
+}
+
+// CreatePod creates a new Pod. This will fail if it already exists.
+func (c *Client) CreatePod(namespace string, item *k8s.Pod) (*k8s.Pod, error) {
+	item.TypeMeta.Kind = "Pod"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Pod
+	_, err := c.do("POST", podGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Pod")
+	}
+	return &out, nil
+}
+
+// ListPods lists all Pods in a namespace
+func (c *Client) ListPods(namespace string, opts *k8s.ListOptions) (*k8s.PodList, error) {
+	var out k8s.PodList
+	_, err := c.do("GET", podGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list Pods")
+	}
+	return &out, nil
+}
+
+// DeletePod deletes a single Pod. It will error if the Pod does not exist.
+func (c *Client) DeletePod(namespace, name string) error {
+	_, err := c.do("DELETE", podGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete Pod")
+}
+
+// UpdatePod will update in place a single Pod. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdatePod(namespace string, item *k8s.Pod) (*k8s.Pod, error) {
+	item.TypeMeta.Kind = "Pod"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Pod
+	_, err := c.do("PUT", podGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update Pod")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/pod_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/pod_test.go
@@ -1,0 +1,44 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPodList(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		list, err := c.ListPods(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+	})
+}
+
+func TestPodCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		/*
+			in := &client.Pod{
+				ObjectMeta: client.ObjectMeta{
+					Name: "test-pod",
+				},
+			}
+			out, err := c.CreatePod(n.Name, in)
+			assert.Nil(t, err)
+			assert.NotNil(t, out)
+
+			list, err := c.ListPods(n.Name, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, list)
+			assert.True(t, len(list.Items) > 0, "should not be empty")
+
+			out, err = c.GetPod(n.Name, in.Name)
+			assert.Nil(t, err)
+			assert.NotNil(t, out)
+
+			err = c.DeletePod(n.Name, in.Name)
+			assert.Nil(t, err)
+		*/
+	})
+}

--- a/deps/github.com/YakLabs/k8s-client/http/replicaset.go
+++ b/deps/github.com/YakLabs/k8s-client/http/replicaset.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func replicasetGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/apis/extensions/v1beta1/namespaces/" + namespace + "/replicasets"
+	}
+	return "/apis/extensions/v1beta1/namespaces/" + namespace + "/replicasets/" + name
+}
+
+// GetReplicaSet fetches a single ReplicaSet
+func (c *Client) GetReplicaSet(namespace, name string) (*k8s.ReplicaSet, error) {
+	var out k8s.ReplicaSet
+	_, err := c.do("GET", replicasetGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get ReplicaSet")
+	}
+	return &out, nil
+}
+
+// CreateReplicaSet creates a new ReplicaSet. This will fail if it already exists.
+func (c *Client) CreateReplicaSet(namespace string, item *k8s.ReplicaSet) (*k8s.ReplicaSet, error) {
+	item.TypeMeta.Kind = "ReplicaSet"
+	item.TypeMeta.APIVersion = "extensions/v1beta1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.ReplicaSet
+	_, err := c.do("POST", replicasetGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create ReplicaSet")
+	}
+	return &out, nil
+}
+
+// ListReplicaSets lists all ReplicaSets in a namespace
+func (c *Client) ListReplicaSets(namespace string, opts *k8s.ListOptions) (*k8s.ReplicaSetList, error) {
+	var out k8s.ReplicaSetList
+	_, err := c.do("GET", replicasetGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list ReplicaSets")
+	}
+	return &out, nil
+}
+
+// DeleteReplicaSet deletes a single ReplicaSet. It will error if the ReplicaSet does not exist.
+func (c *Client) DeleteReplicaSet(namespace, name string) error {
+	_, err := c.do("DELETE", replicasetGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete ReplicaSet")
+}
+
+// UpdateReplicaSet will update in place a single ReplicaSet. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateReplicaSet(namespace string, item *k8s.ReplicaSet) (*k8s.ReplicaSet, error) {
+	item.TypeMeta.Kind = "ReplicaSet"
+	item.TypeMeta.APIVersion = "extensions/v1beta1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.ReplicaSet
+	_, err := c.do("PUT", replicasetGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update ReplicaSet")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/replicaset_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/replicaset_test.go
@@ -1,0 +1,44 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplicaSetList(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		list, err := c.ListReplicaSets(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+	})
+}
+
+func TestReplicaSetCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		/*
+			in := &client.ReplicaSet{
+				ObjectMeta: client.ObjectMeta{
+					Name: "test-deployment",
+				},
+			}
+			out, err := c.CreateReplicaSet(n.Name, in)
+			assert.Nil(t, err)
+			assert.NotNil(t, out)
+
+			list, err := c.ListReplicaSets(n.Name, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, list)
+			assert.True(t, len(list.Items) > 0, "should not be empty")
+
+			out, err = c.GetReplicaSet(n.Name, in.Name)
+			assert.Nil(t, err)
+			assert.NotNil(t, out)
+
+			err = c.DeleteReplicaSet(n.Name, in.Name)
+			assert.Nil(t, err)
+		*/
+	})
+}

--- a/deps/github.com/YakLabs/k8s-client/http/secret.go
+++ b/deps/github.com/YakLabs/k8s-client/http/secret.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func secretGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/api/v1/namespaces/" + namespace + "/secrets"
+	}
+	return "/api/v1/namespaces/" + namespace + "/secrets/" + name
+}
+
+// GetSecret fetches a single Secret
+func (c *Client) GetSecret(namespace, name string) (*k8s.Secret, error) {
+	var out k8s.Secret
+	_, err := c.do("GET", secretGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get Secret")
+	}
+	return &out, nil
+}
+
+// CreateSecret creates a new Secret. This will fail if it already exists.
+func (c *Client) CreateSecret(namespace string, item *k8s.Secret) (*k8s.Secret, error) {
+	item.TypeMeta.Kind = "Secret"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Secret
+	_, err := c.do("POST", secretGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Secret")
+	}
+	return &out, nil
+}
+
+// ListSecrets lists all Secrets in a namespace
+func (c *Client) ListSecrets(namespace string, opts *k8s.ListOptions) (*k8s.SecretList, error) {
+	var out k8s.SecretList
+	_, err := c.do("GET", secretGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list Secrets")
+	}
+	return &out, nil
+}
+
+// DeleteSecret deletes a single Secret. It will error if the Secret does not exist.
+func (c *Client) DeleteSecret(namespace, name string) error {
+	_, err := c.do("DELETE", secretGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete Secret")
+}
+
+// UpdateSecret will update in place a single Secret. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateSecret(namespace string, item *k8s.Secret) (*k8s.Secret, error) {
+	item.TypeMeta.Kind = "Secret"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Secret
+	_, err := c.do("PUT", secretGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update Secret")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/secret_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/secret_test.go
@@ -1,0 +1,39 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecretList(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		list, err := c.ListSecrets(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+	})
+}
+
+func TestSecretCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		in := client.NewSecret(n.Name, "test-secret")
+
+		out, err := c.CreateSecret(n.Name, in)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		list, err := c.ListSecrets(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+		assert.True(t, len(list.Items) > 0, "should not be empty")
+
+		out, err = c.GetSecret(n.Name, in.Name)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		err = c.DeleteSecret(n.Name, in.Name)
+		assert.Nil(t, err)
+	})
+}

--- a/deps/github.com/YakLabs/k8s-client/http/service.go
+++ b/deps/github.com/YakLabs/k8s-client/http/service.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func serviceGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/api/v1/namespaces/" + namespace + "/services"
+	}
+	return "/api/v1/namespaces/" + namespace + "/services/" + name
+}
+
+// GetService fetches a single Service
+func (c *Client) GetService(namespace, name string) (*k8s.Service, error) {
+	var out k8s.Service
+	_, err := c.do("GET", serviceGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get Service")
+	}
+	return &out, nil
+}
+
+// CreateService creates a new Service. This will fail if it already exists.
+func (c *Client) CreateService(namespace string, item *k8s.Service) (*k8s.Service, error) {
+	item.TypeMeta.Kind = "Service"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Service
+	_, err := c.do("POST", serviceGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Service")
+	}
+	return &out, nil
+}
+
+// ListServices lists all Services in a namespace
+func (c *Client) ListServices(namespace string, opts *k8s.ListOptions) (*k8s.ServiceList, error) {
+	var out k8s.ServiceList
+	_, err := c.do("GET", serviceGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list Services")
+	}
+	return &out, nil
+}
+
+// DeleteService deletes a single Service. It will error if the Service does not exist.
+func (c *Client) DeleteService(namespace, name string) error {
+	_, err := c.do("DELETE", serviceGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete Service")
+}
+
+// UpdateService will update in place a single Service. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateService(namespace string, item *k8s.Service) (*k8s.Service, error) {
+	item.TypeMeta.Kind = "Service"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.Service
+	_, err := c.do("PUT", serviceGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update Service")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/service_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/service_test.go
@@ -1,0 +1,45 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceList(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		list, err := c.ListServices(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+	})
+}
+
+/*
+func TestServiceCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+
+		in := &client.Service{
+			ObjectMeta: client.ObjectMeta{
+				Name: "test-service",
+			},
+		}
+		out, err := c.CreateService(n.Name, in)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		list, err := c.ListServices(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+		assert.True(t, len(list.Items) > 0, "should not be empty")
+
+		out, err = c.GetService(n.Name, in.Name)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		err = c.DeleteService(n.Name, in.Name)
+		assert.Nil(t, err)
+	})
+}
+*/

--- a/deps/github.com/YakLabs/k8s-client/http/serviceaccount.go
+++ b/deps/github.com/YakLabs/k8s-client/http/serviceaccount.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/pkg/errors"
+)
+
+func serviceaccountGeneratePath(namespace, name string) string {
+	if name == "" {
+		return "/api/v1/namespaces/" + namespace + "/serviceaccounts"
+	}
+	return "/api/v1/namespaces/" + namespace + "/serviceaccounts/" + name
+}
+
+// GetServiceAccount fetches a single ServiceAccount
+func (c *Client) GetServiceAccount(namespace, name string) (*k8s.ServiceAccount, error) {
+	var out k8s.ServiceAccount
+	_, err := c.do("GET", serviceaccountGeneratePath(namespace, name), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get ServiceAccount")
+	}
+	return &out, nil
+}
+
+// CreateServiceAccount creates a new ServiceAccount. This will fail if it already exists.
+func (c *Client) CreateServiceAccount(namespace string, item *k8s.ServiceAccount) (*k8s.ServiceAccount, error) {
+	item.TypeMeta.Kind = "ServiceAccount"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.ServiceAccount
+	_, err := c.do("POST", serviceaccountGeneratePath(namespace, ""), item, &out, 201)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create ServiceAccount")
+	}
+	return &out, nil
+}
+
+// ListServiceAccounts lists all ServiceAccounts in a namespace
+func (c *Client) ListServiceAccounts(namespace string, opts *k8s.ListOptions) (*k8s.ServiceAccountList, error) {
+	var out k8s.ServiceAccountList
+	_, err := c.do("GET", serviceaccountGeneratePath(namespace, "")+"?"+listOptionsQuery(opts), nil, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list ServiceAccounts")
+	}
+	return &out, nil
+}
+
+// DeleteServiceAccount deletes a single ServiceAccount. It will error if the ServiceAccount does not exist.
+func (c *Client) DeleteServiceAccount(namespace, name string) error {
+	_, err := c.do("DELETE", serviceaccountGeneratePath(namespace, name), nil, nil)
+	return errors.Wrap(err, "failed to delete ServiceAccount")
+}
+
+// UpdateServiceAccount will update in place a single ServiceAccount. Generally, you should call
+// Get and then use that object for updates to ensure resource versions
+// avoid update conflicts
+func (c *Client) UpdateServiceAccount(namespace string, item *k8s.ServiceAccount) (*k8s.ServiceAccount, error) {
+	item.TypeMeta.Kind = "ServiceAccount"
+	item.TypeMeta.APIVersion = "v1"
+	item.ObjectMeta.Namespace = namespace
+
+	var out k8s.ServiceAccount
+	_, err := c.do("PUT", serviceaccountGeneratePath(namespace, item.Name), item, &out)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update ServiceAccount")
+	}
+	return &out, nil
+}

--- a/deps/github.com/YakLabs/k8s-client/http/serviceaccount_test.go
+++ b/deps/github.com/YakLabs/k8s-client/http/serviceaccount_test.go
@@ -1,0 +1,42 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceAccountList(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		list, err := c.ListServiceAccounts(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+	})
+}
+
+func TestServiceAccountCreate(t *testing.T) {
+	withTestNamespace(t, func(t *testing.T, c *http.Client, n *client.Namespace) {
+		in := &client.ServiceAccount{
+			ObjectMeta: client.ObjectMeta{
+				Name: "test-service-account",
+			},
+		}
+		out, err := c.CreateServiceAccount(n.Name, in)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		list, err := c.ListServiceAccounts(n.Name, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, list)
+		assert.True(t, len(list.Items) > 0, "should not be empty")
+
+		out, err = c.GetServiceAccount(n.Name, in.Name)
+		assert.Nil(t, err)
+		assert.NotNil(t, out)
+
+		err = c.DeleteServiceAccount(n.Name, in.Name)
+		assert.Nil(t, err)
+	})
+}

--- a/deps/github.com/YakLabs/k8s-client/ingress.go
+++ b/deps/github.com/YakLabs/k8s-client/ingress.go
@@ -1,0 +1,125 @@
+package client
+
+import "github.com/YakLabs/k8s-client/intstr"
+
+type (
+	// IngressInterface has methods to work with Ingress resources.
+	IngressInterface interface {
+		CreateIngress(namespace string, item *Ingress) (*Ingress, error)
+		GetIngress(namespace, name string) (result *Ingress, err error)
+		ListIngresses(namespace string, opts *ListOptions) (*IngressList, error)
+		DeleteIngress(namespace, name string) error
+		UpdateIngress(namespace string, item *Ingress) (*Ingress, error)
+	}
+
+	// Ingress holds secret data of a certain type.
+	Ingress struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// Spec is the desired state of the Ingress.
+		Spec *IngressSpec `json:"spec,omitempty"`
+		// Status is the current state of the Ingress.
+		Status *IngressStatus `json:"status,omitempty"`
+	}
+
+	// IngressList holds a list of ingresses.
+	IngressList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		Items []Ingress `json:"items"`
+	}
+
+	// IngressSpec describes the Ingress the user wishes to exist.
+	IngressSpec struct {
+		// A default backend capable of servicing requests that don’t match any rule.
+		// At least one of backend or rules must be specified.
+		// This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.
+		Backend *IngressBackend `json:"backend,omitempty"`
+
+		// TLS configuration.
+		// Currently the Ingress only supports a single TLS port, 443.
+		// If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname
+		// specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+		TLS []IngressTLS `json:"tls,omitempty"`
+
+		// A list of host rules used to configure the Ingress.
+		// If unspecified, or no rule matches, all traffic is sent to the default backend.
+		Rules []IngressRule `json:"rules,omitempty"`
+	}
+
+	// IngressBackend describes all endpoints for a given service and port.
+	IngressBackend struct {
+		//		Specifies the name of the referenced service.
+		ServiceName string `json:"serviceName"`
+
+		// Specifies the port of the referenced service.
+		ServicePort intstr.IntOrString `json:"servicePort"`
+	}
+
+	// IngressTLS describes the transport layer security associated with an Ingress.
+	IngressTLS struct {
+		// Hosts are a list of hosts included in the TLS certificate.
+		// The values in this list must match the name/s used in the tlsSecret.
+		// Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+		Hosts []string `json:"hosts,omitempy"`
+
+		// SecretName is the name of the secret used to terminate SSL traffic on 443.
+		// Field is left optional to allow SSL routing based on SNI hostname alone.
+		// If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule,
+		// the SNI host is used for termination and value of the Host header is used for routing.
+		SecretName string `json:"secretName,omitempty"`
+	}
+
+	// IngressRule represents the rules mapping the paths under a specified host to the related backend services.
+	// Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+	IngressRule struct {
+		// Host is the fully qualified domain name of a network host, as defined by RFC 3986.
+		// Note the following deviations from the "host" part of the URI as defined in the RFC:
+		// 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the IP in the Spec of the parent Ingress.
+		// 2. The : delimiter is not respected because ports are not allowed.
+		// Currently the port of an Ingress is implicitly :80 for http and :443 for https.
+		// Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue.
+		// If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+		Host string `json:"host,omitempty"`
+
+		HTTP *HTTPIngressRuleValue `json:"http,omitempty"`
+	}
+
+	// HTTPIngressRuleValue is a list of http selectors pointing to backends.
+	// In the example: http://<host>/<path>?<searchpart> → backend where where parts of the url correspond to RFC 3986,
+	// this resource will be used to match against everything after the last / and before the first ? or #.
+	HTTPIngressRuleValue struct {
+		// A collection of paths that map requests to backends
+		Paths []HTTPIngressPath `json:"paths,omitempty"`
+	}
+
+	// HTTPIngressPath associates a path regex with a backend.
+	// Incoming urls matching the path are forwarded to the backend.
+	HTTPIngressPath struct {
+		// Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax,
+		// not the perl syntax) matched against the path of an incoming request.
+		// Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+		// Paths must begin with a /. If unspecified, the path defaults to a catch all sending traffic to the backend.
+		Path string `json:"path,omitempty"`
+
+		// Backend defines the referenced service endpoint to which the traffic will be forwarded to.
+		Backend IngressBackend `json:"backend"`
+	}
+
+	// IngressStatus describe the current state of the Ingress.
+	IngressStatus struct {
+		// LoadBalancer contains the current status of the load-balancer.
+		LoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
+	}
+)
+
+// NewIngress creates a new Ingress struct
+func NewIngress(namespace, name string) *Ingress {
+	return &Ingress{
+		TypeMeta:   NewTypeMeta("Ingress", "extensions/v1beta1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Spec:       &IngressSpec{},
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/intstr/intstr.go
+++ b/deps/github.com/YakLabs/k8s-client/intstr/intstr.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package intstr
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/google/gofuzz"
+)
+
+// IntOrString is a type that can hold an int32 or a string.  When used in
+// JSON or YAML marshalling and unmarshalling, it produces or consumes the
+// inner type.  This allows you to have, for example, a JSON field that can
+// accept a name or number.
+// TODO: Rename to Int32OrString
+//
+// +protobuf=true
+// +protobuf.options.(gogoproto.goproto_stringer)=false
+type IntOrString struct {
+	Type   Type
+	IntVal int32
+	StrVal string
+}
+
+// Type represents the stored type of IntOrString.
+type Type int
+
+const (
+	Int    Type = iota // The IntOrString holds an int.
+	String             // The IntOrString holds a string.
+)
+
+// FromInt creates an IntOrString object with an int32 value. It is
+// your responsibility not to call this method with a value greater
+// than int32.
+// TODO: convert to (val int32)
+func FromInt(val int) IntOrString {
+	return IntOrString{Type: Int, IntVal: int32(val)}
+}
+
+// FromString creates an IntOrString object with a string value.
+func FromString(val string) IntOrString {
+	return IntOrString{Type: String, StrVal: val}
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (intstr *IntOrString) UnmarshalJSON(value []byte) error {
+	if value[0] == '"' {
+		intstr.Type = String
+		return json.Unmarshal(value, &intstr.StrVal)
+	}
+	intstr.Type = Int
+	return json.Unmarshal(value, &intstr.IntVal)
+}
+
+// String returns the string value, or the Itoa of the int value.
+func (intstr *IntOrString) String() string {
+	if intstr.Type == String {
+		return intstr.StrVal
+	}
+	return strconv.Itoa(intstr.IntValue())
+}
+
+// IntValue returns the IntVal if type Int, or if
+// it is a String, will attempt a conversion to int.
+func (intstr *IntOrString) IntValue() int {
+	if intstr.Type == String {
+		i, _ := strconv.Atoi(intstr.StrVal)
+		return i
+	}
+	return int(intstr.IntVal)
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (intstr IntOrString) MarshalJSON() ([]byte, error) {
+	switch intstr.Type {
+	case Int:
+		return json.Marshal(intstr.IntVal)
+	case String:
+		return json.Marshal(intstr.StrVal)
+	default:
+		return []byte{}, fmt.Errorf("impossible IntOrString.Type")
+	}
+}
+
+func (intstr *IntOrString) Fuzz(c fuzz.Continue) {
+	if intstr == nil {
+		return
+	}
+	if c.RandBool() {
+		intstr.Type = Int
+		c.Fuzz(&intstr.IntVal)
+		intstr.StrVal = ""
+	} else {
+		intstr.Type = String
+		intstr.IntVal = 0
+		c.Fuzz(&intstr.StrVal)
+	}
+}
+
+func GetValueFromIntOrPercent(intOrPercent *IntOrString, total int, roundUp bool) (int, error) {
+	value, isPercent, err := getIntOrPercentValue(intOrPercent)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value for IntOrString: %v", err)
+	}
+	if isPercent {
+		if roundUp {
+			value = int(math.Ceil(float64(value) * (float64(total)) / 100))
+		} else {
+			value = int(math.Floor(float64(value) * (float64(total)) / 100))
+		}
+	}
+	return value, nil
+}
+
+func getIntOrPercentValue(intOrStr *IntOrString) (int, bool, error) {
+	switch intOrStr.Type {
+	case Int:
+		return intOrStr.IntValue(), false, nil
+	case String:
+		s := strings.Replace(intOrStr.StrVal, "%", "", -1)
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
+		}
+		return int(v), true, nil
+	}
+	return 0, false, fmt.Errorf("invalid value: neither int nor percentage")
+}

--- a/deps/github.com/YakLabs/k8s-client/job.go
+++ b/deps/github.com/YakLabs/k8s-client/job.go
@@ -1,0 +1,102 @@
+package client
+
+type (
+	// JobInterface has methods to work with Job resources.
+	JobInterface interface {
+		CreateJob(namespace string, item *Job) (*Job, error)
+		GetJob(namespace, name string) (result *Job, err error)
+		ListJobs(namespace string, opts *ListOptions) (*JobList, error)
+		DeleteJob(namespace, name string) error
+		UpdateJob(namespace string, item *Job) (*Job, error)
+	}
+
+	// Job represents the configuration of a single job.
+	Job struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// Specification of the desired behavior of the Job.
+		Spec *JobSpec `json:"spec,omitempty"`
+
+		// Most recently observed status of the DaemonSet.
+		Status *JobStatus `json:"status,omitempty"`
+	}
+
+	// JobSpec describes how the job execution will look like.
+	JobSpec struct {
+		// Parallelism specifies the maximum desired number of pods the job should run at any given time.
+		// The actual number of pods running in steady state will be less than this number when
+		// ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism.
+		Parallelism int32 `json:"parallelism,omitempty"`
+		// Completions specifies the desired number of successfully finished pods the job should be run with.
+		// Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.
+		// Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job.
+		Completions int32 `json:"completions,omitempty"`
+		// Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
+		ActiveDeadlineSeconds int64 `json:"activeDeadlineSeconds,omitempty"`
+		// Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you.
+		Selector *LabelSelector `json:"selector,omitempty"`
+		// ManualSelector controls generation of pod labels and pod selectors.
+		// Leave manualSelector unset unless you are certain what you are doing.
+		// When false or unset, the system pick labels unique to this job and appends those labels to the pod template.
+		// When true, the user is responsible for picking unique labels and specifying the selector.
+		// Failure to pick a unique label may cause this and other jobs to not function correctly.
+		// However, You may see manualSelector=true in jobs that were created with the old extensions/v1beta1 API.
+		ManualSelector bool `json:"manualSelector,omitempty"`
+		// Template is the object that describes the pod that will be created when executing a job.
+		Template PodTemplateSpec `json:"template"`
+	}
+
+	// JobStatus represents the current status of a job.
+	JobStatus struct {
+		// Conditions represent the latest available observations of an object’s current state
+		Conditions []JobCondition `json:"conditions,omitempty"`
+		// StartTime represents time when the job was acknowledged by the Job Manager.
+		// It is not guaranteed to be set in happens-before order across separate operations.
+		// It is represented in RFC3339 form and is in UTC.
+		StartTime Time `json:"startTime,omitempty"`
+		// CompletionTime represents time when the job was completed.
+		// It is not guaranteed to be set in happens-before order across separate operations.
+		// It is represented in RFC3339 form and is in UTC.
+		CompletionTime Time `json:"completionTime,omitempty"`
+		// Active is the number of actively running pods.
+		Active int32 `json:"active,omitempty"`
+		// Succeeded is the number of pods which reached Phase Succeeded.
+		Succeeded int32 `json:"succeeded,omitempty"`
+		// Failed is the number of pods which reached Phase Failed.
+		Failed int32 `json:"failed,omitempty"`
+	}
+
+	// JobCondition describes current state of a job.
+	JobCondition struct {
+		// Type of job condition, Complete or Failed.
+		Type string `json:"type"`
+		// Status of the condition, one of True, False, Unknown.
+		Status string `json:"status"`
+		// Last time the condition was checked.
+		LastProbeTime Time `json:"lastProbeTime,omitempty"`
+		// Last time the condition transit from one status to another.
+		LastTransitionTime Time `json:"lastTransitionTime,omitempty"`
+		// (brief) reason for the condition’s last transition.
+		Reason string `json:"reason,omitempty"`
+		// Human readable message indicating details about last transition.
+		Message string `json:"message,omitempty"`
+	}
+
+	JobList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		// Items is the list of jobs.
+		Items []Job `json:"items"`
+	}
+)
+
+// NewJob creates a new Job struct
+func NewJob(namespace, name string) *Job {
+	return &Job{
+		TypeMeta:   NewTypeMeta("Job", "batch/v1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Spec:       &JobSpec{},
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/namespace.go
+++ b/deps/github.com/YakLabs/k8s-client/namespace.go
@@ -1,0 +1,44 @@
+package client
+
+type (
+	NamespaceInterface interface {
+		CreateNamespace(item *Namespace) (*Namespace, error)
+		GetNamespace(name string) (result *Namespace, err error)
+		ListNamespaces(opts *ListOptions) (*NamespaceList, error)
+		DeleteNamespace(name string) error
+		UpdateNamespace(item *Namespace) (*Namespace, error)
+	}
+
+	NamespaceSpec struct {
+		Finalizers []FinalizerName
+	}
+
+	NamespacePhase string
+
+	NamespaceStatus struct {
+		Phase NamespacePhase `json:"phase,omitempty"`
+	}
+
+	Namespace struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+		Spec       *NamespaceSpec   `json:"spec,omitempty"`
+		Status     *NamespaceStatus `json:"status,omitempty"`
+	}
+
+	NamespaceList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		Items []Namespace `json:"items"`
+	}
+)
+
+// NewNamespace creates a new namespace struct
+func NewNamespace(name string) *Namespace {
+	return &Namespace{
+		TypeMeta:   NewTypeMeta("Namespace", "v1"),
+		ObjectMeta: NewObjectMeta(name, name),
+		Spec:       &NamespaceSpec{},
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/node.go
+++ b/deps/github.com/YakLabs/k8s-client/node.go
@@ -1,0 +1,78 @@
+package client
+
+type (
+	NodeInterface interface {
+		CreateNode(item *Node) (*Node, error)
+		GetNode(name string) (result *Node, err error)
+		ListNodes(opts *ListOptions) (*NodeList, error)
+		DeleteNode(name string) error
+		UpdateNode(item *Node) (*Node, error)
+	}
+
+	NodeSpec struct {
+		PodCIDR       string `json:"podCIDR,omitempty"`
+		ExternalID    string `json:"externalID,omitempty"`
+		ProviderID    string `json:"providerID,omitempty"`
+		Unschedulable bool   `json:"unschedulable,omitempty"`
+	}
+
+	NodePhase         string
+	NodeConditionType string
+	NodeAddressType   string
+
+	NodeAddress struct {
+		Type    NodeAddressType `json:"type"`
+		Address string          `json:"address"`
+	}
+
+	NodeCondition struct {
+		Type    NodeConditionType `json:"type"`
+		Status  ConditionStatus   `json:"status"`
+		Reason  string            `json:"reason,omitempty"`
+		Message string            `json:"message,omitempty"`
+	}
+
+	NodeStatus struct {
+		Phase      NodePhase       `json:"phase,omitempty"`
+		Conditions []NodeCondition `json:"conditions,omitempty"`
+		Addresses  []NodeAddress   `json:"addresses,omitempty"`
+		NodeInfo   *NodeSystemInfo `json:"nodeInfo,omitempty"`
+	}
+
+	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
+	NodeSystemInfo struct {
+		// MachineID reported by the node. For unique machine identification in the cluster this field is prefered.
+		MachineID string `json:"machineID"`
+		// SystemUUID reported by the node. For unique machine identification MachineID is prefered. This field is specific to Red Hat hosts
+		SystemUUID string `json:"systemUUID"`
+		// Boot ID reported by the node.
+		BootID string `json:"bootID"`
+		// Kernel Version reported by the node from uname -r (e.g. 3.16.0-0.bpo.4-amd64).
+		KernelVersion string `json:"kernelVersion"`
+		// OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
+		OSImage string `json:"osImage"`
+		// ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
+		ContainerRuntimeVersion string `json:"containerRuntimeVersion"`
+		// Kubelet Version reported by the node.
+		KubeletVersion string `json:"kubeletVersion"`
+		// KubeProxy Version reported by the node.
+		KubeProxyVersion string `json:"kubeProxyVersion"`
+		// The Operating System reported by the node.
+		OperatingSystem string `json:"operatingSystem"`
+		// The Architecture reported by the node.
+		Architecture string `json:"architecture"`
+	}
+
+	Node struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+		Spec       NodeSpec   `json:"spec,omitempty"`
+		Status     NodeStatus `json:"status,omitempty"`
+	}
+
+	NodeList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+		Items    []Node `json:"items"`
+	}
+)

--- a/deps/github.com/YakLabs/k8s-client/pod.go
+++ b/deps/github.com/YakLabs/k8s-client/pod.go
@@ -1,0 +1,428 @@
+package client
+
+import "github.com/YakLabs/k8s-client/intstr"
+
+const (
+	RestartPolicyAlways    RestartPolicy = "Always"
+	RestartPolicyOnFailure RestartPolicy = "OnFailure"
+	RestartPolicyNever     RestartPolicy = "Never"
+	DNSClusterFirst        DNSPolicy     = "ClusterFirst"
+	DNSDefault             DNSPolicy     = "Default"
+	// URISchemeHTTP means that the scheme used will be http://
+	URISchemeHTTP URIScheme = "HTTP"
+	// URISchemeHTTPS means that the scheme used will be https://
+	URISchemeHTTPS URIScheme = "HTTPS"
+	// CPU, in cores. (500m = .5 cores)
+	ResourceCPU ResourceName = "cpu"
+	// Memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	ResourceMemory ResourceName = "memory"
+	// Volume size, in bytes (e,g. 5Gi = 5GiB = 5 * 1024 * 1024 * 1024)
+	ResourceStorage ResourceName = "storage"
+	// PullAlways means that kubelet always attempts to pull the latest image.  Container will fail If the pull fails.
+	PullAlways PullPolicy = "Always"
+	// PullNever means that kubelet never pulls an image, but only uses a local image.  Container will fail if the image isn't present
+	PullNever PullPolicy = "Never"
+	// PullIfNotPresent means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+	PullIfNotPresent PullPolicy = "IfNotPresent"
+	// PodPending means the pod has been accepted by the system, but one or more of the containers
+	// has not been started. This includes time before being bound to a node, as well as time spent
+	// pulling images onto the host.
+	PodPending PodPhase = "Pending"
+	// PodRunning means the pod has been bound to a node and all of the containers have been started.
+	// At least one container is still running or is in the process of being restarted.
+	PodRunning PodPhase = "Running"
+	// PodSucceeded means that all containers in the pod have voluntarily terminated
+	// with a container exit code of 0, and the system is not going to restart any of these containers.
+	PodSucceeded PodPhase = "Succeeded"
+	// PodFailed means that all containers in the pod have terminated, and at least one container has
+	// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+	PodFailed PodPhase = "Failed"
+	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
+	// to an error in communicating with the host of the pod.
+	PodUnknown PodPhase = "Unknown"
+)
+
+type (
+	PodInterface interface {
+		CreatePod(namespace string, item *Pod) (*Pod, error)
+		GetPod(namespace, name string) (result *Pod, err error)
+		ListPods(namespace string, opts *ListOptions) (*PodList, error)
+		DeletePod(namespace, name string) error
+		UpdatePod(namespace string, item *Pod) (*Pod, error)
+	}
+
+	Pod struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+		Spec       *PodSpec   `json:"spec,omitempty"`
+		Status     *PodStatus `json:"status,omitempty"`
+	}
+
+	PodList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+		Items    []Pod `json:"items"`
+	}
+
+	// PodSpec is a description of a pod.
+	PodSpec struct {
+		// List of volumes that can be mounted by containers belonging to the pod.
+		Volumes []Volume `json:"volumes,omitempty"`
+		// List of containers belonging to the pod. Containers cannot currently be added or removed.
+		// There must be at least one container in a Pod. Cannot be updated.
+		Containers []Container `json:"containers"`
+		// Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always.
+		RestartPolicy RestartPolicy `json:"restartPolicy,omitempty"`
+		// Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+		// Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil,
+		// the default grace period will be used instead.
+		//  The grace period is the duration in seconds after the processes running in the pod are sent a termination
+		// signal and the time when the processes are forcibly halted with a kill signal.
+		// Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
+		TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+		// Optional duration in seconds the pod may be active on the node relative to StartTime before the system will
+		// actively try to mark it failed and kill associated containers. Value must be a positive integer.
+		ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
+		// Set DNS policy for containers within the pod. One of ClusterFirst or Default. Defaults to "ClusterFirst".
+		DNSPolicy DNSPolicy `json:"dnsPolicy,omitempty"`
+		// NodeSelector is a selector which must be true for the pod to fit on a node.
+		// Selector which must match a node’s labels for the pod to be scheduled on that node.
+		NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+		// ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+		ServiceAccountName string `json:"serviceAccountName,omitempty"`
+		// NodeName is a request to schedule this pod onto a specific node.
+		// If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+		NodeName string `json:"nodeName,omitempty"`
+		// Host networking requested for this pod. Use the host’s network namespace.
+		// If this option is set, the ports that will be used must be specified. Default to false.
+		HostNetwork bool `json:"hostNetwork,omitempty"`
+		// Use the host’s pid namespace. Optional: Default to false.
+		HostPID bool `json:"hostPID,omitempty"`
+		// Use the host’s ipc namespace. Optional: Default to false.
+		HostIPC bool `json:"hostIPC,omitempty"`
+		// SecurityContext holds pod-level security attributes and common container settings.
+		// Optional: Defaults to empty. See type description for default values of each field.
+		SecurityContext *PodSecurityContext `json:"securityContext,omitempty"`
+		// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+		// If specified, these secrets will be passed to individual puller implementations for them to use.
+		// For example, in the case of docker, only DockerConfig type secrets are honored.
+		ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty"`
+		// Specifies the hostname of the Pod If not specified, the pod’s hostname will be set to a system-defined value.
+		Hostname string `json:"hostname,omitempty"`
+		// If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+		// If not specified, the pod will not have a domainname at all.
+		Subdomain string `json:"subdomain,omitempty"`
+	}
+
+	PodStatus struct {
+		Phase             PodPhase          `json:"phase,omitempty"`
+		Conditions        []PodCondition    `json:"conditions,omitempty"`
+		Message           string            `json:"message,omitempty"`
+		Reason            string            `json:"reason,omitempty"`
+		HostIP            string            `json:"hostIP,omitempty"`
+		PodIP             string            `json:"podIP,omitempty"`
+		StartTime         *Time             `json:"startTime,omitempty"`
+		ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty"`
+	}
+
+	PodCondition struct {
+		Type               PodConditionType `json:"type"`
+		Status             ConditionStatus  `json:"status"`
+		LastProbeTime      Time             `json:"lastProbeTime,omitempty"`
+		LastTransitionTime Time             `json:"lastTransitionTime,omitempty"`
+		Reason             string           `json:"reason,omitempty"`
+		Message            string           `json:"message,omitempty"`
+	}
+
+	// PodSecurityContext holds pod-level security attributes and common container settings.
+	// Some fields are also present in container.securityContext.
+	// Field values of container.securityContext take precedence over field values of PodSecurityContext.
+	PodSecurityContext struct {
+		// The SELinux context to be applied to all containers. If unspecified, the container runtime will
+		// allocate a random SELinux context for each container. May also be set in SecurityContext.
+		// If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+		SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
+		// The UID to run the entrypoint of the container process.
+		// Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.
+		// If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+		RunAsUser int64 `json:"runAsUser,omitempty"`
+		// Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure
+		// that it does not run as UID 0 (root) and fail to start the container if it does.
+		// If unset or false, no such validation will be performed. May also be set in SecurityContext.
+		// If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+		RunAsNonRoot bool `json:"runAsNonRoot,omitempty"`
+		// A list of groups applied to the first process run in each container, in addition to the container’s primary GID.
+		// If unspecified, no groups will be added to any container.
+		SupplementalGroups []int32 `json:"supplementalGroups,omitempty"`
+		// A special supplemental group that applies to all containers in a pod.
+		// Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+		// 1. The owning GID will be the FSGroup
+		// 2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+		// 3. The permission bits are OR’d with rw-rw
+		FSGroup int64 `json:"fsGroup,omitempty"`
+	}
+
+	// SELinuxOptions are the labels to be applied to the container
+	SELinuxOptions struct {
+		// User is a SELinux user label that applies to the container.
+		User string `json:"user,omitempty"`
+		// Role is a SELinux role label that applies to the container.
+		Role string `json:"role,omitempty"`
+		// Type is a SELinux type label that applies to the container.
+		Type string `json:"type,omitempty"`
+		// Level is SELinux level label that applies to the container.
+		Level string `json:"level,omitempty"`
+	}
+
+	PodConditionType string
+	StorageMedium    string
+	RestartPolicy    string
+	DNSPolicy        string
+	Protocol         string
+	URIScheme        string
+
+	Volume struct {
+		Name         string `json:"name"`
+		VolumeSource `json:",inline,omitempty"`
+	}
+
+	VolumeSource struct {
+		EmptyDir *EmptyDirVolumeSource `json:"emptyDir,omitempty"`
+		HostPath *HostPathVolumeSource `json:"hostPath,omitempty"`
+		Secret   *SecretVolumeSource   `json:"secret,omitempty"`
+	}
+
+	// Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+	EmptyDirVolumeSource struct {
+		Medium StorageMedium `json:"medium,omitempty"`
+	}
+
+	// Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+	HostPathVolumeSource struct {
+		// Path of the directory on the host.
+		Path string `json:"path"`
+	}
+
+	// Adapts a Secret into a volume. The contents of the target Secret’s Data field will be presented in a volume as files
+	// using the keys in the Data field as the file names.
+	// Secret volumes support ownership management and SELinux relabeling.
+	SecretVolumeSource struct {
+		// Name of the secret in the pod’s namespace to use.
+		SecretName string `json:"secretName,omitempty"`
+		// If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume
+		// as a file whose name is the key and content is the value.
+		// If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present.
+		// If a key is specified which is not present in the Secret, the volume setup will error.
+		// Paths must be relative and may not contain the .. path or start with ...
+		Items []KeyToPath `json:"items,omitempty"`
+		// Optional: mode bits to use on created files by default. Must be a value between 0 and 0777.
+		// Defaults to 0644. Directories within the path are not affected by this setting.
+		// This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+		DefaultMode int32 `json:"defaultMode,omitempty"`
+	}
+
+	// Maps a string key to a path within a volume.
+	KeyToPath struct {
+		// The key to project.
+		Key string `json:"key"`
+		// The relative path of the file to map the key to. May not be an absolute path. May not contain the path element ... May not start with the string ...
+		Path string `json:"path"`
+		// Optional: mode bits to use on this file, must be a value between 0 and 0777.
+		// If not specified, the volume defaultMode will be used. This might be in conflict with other options
+		// that affect the file mode, like fsGroup, and the result can be other mode bits set.
+		Mode int32 `json:"mode,omitempty"`
+	}
+
+	Container struct {
+		Name                   string                `json:"name"`
+		Image                  string                `json:"image"`
+		Command                []string              `json:"command,omitempty"`
+		Args                   []string              `json:"args,omitempty"`
+		WorkingDir             string                `json:"workingDir,omitempty"`
+		Ports                  []ContainerPort       `json:"ports,omitempty"`
+		Env                    []EnvVar              `json:"env,omitempty"`
+		Resources              *ResourceRequirements `json:"resources,omitempty"`
+		VolumeMounts           []VolumeMount         `json:"volumeMounts,omitempty"`
+		LivenessProbe          *Probe                `json:"livenessProbe,omitempty"`
+		ReadinessProbe         *Probe                `json:"readinessProbe,omitempty"`
+		Lifecycle              *Lifecycle            `json:"lifecycle,omitempty"`
+		TerminationMessagePath string                `json:"terminationMessagePath,omitempty"`
+		ImagePullPolicy        PullPolicy            `json:"imagePullPolicy"`
+		Stdin                  bool                  `json:"stdin,omitempty"`
+		StdinOnce              bool                  `json:"stdinOnce,omitempty"`
+		TTY                    bool                  `json:"tty,omitempty"`
+	}
+
+	ContainerPort struct {
+		Name          string   `json:"name,omitempty"`
+		HostPort      int      `json:"hostPort,omitempty"`
+		ContainerPort int      `json:"containerPort"`
+		Protocol      Protocol `json:"protocol,omitempty"`
+		HostIP        string   `json:"hostIP,omitempty"`
+	}
+
+	EnvVar struct {
+		Name      string        `json:"name"`
+		Value     string        `json:"value,omitempty"`
+		ValueFrom *EnvVarSource `json:"valueFrom,omitempty"`
+	}
+
+	EnvVarSource struct {
+		FieldRef        *ObjectFieldSelector  `json:"fieldRef,omitempty"`
+		ConfigMapKeyRef *ConfigMapKeySelector `json:"configMapKeyRef,omitempty"`
+		SecretKeyRef    *SecretKeySelector    `json:"secretKeyRef,omitempty"`
+	}
+
+	// VolumeMount describes a mounting of a Volume within a container.
+	VolumeMount struct {
+		// Required: This must match the Name of a Volume [above].
+		Name string `json:"name"`
+		// Optional: Defaults to false (read-write).
+		ReadOnly bool `json:"readOnly,omitempty"`
+		// Required. Must not contain ':'.
+		MountPath string `json:"mountPath"`
+	}
+
+	// Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+	Probe struct {
+		// The action taken to determine the health of a container
+		Handler `json:",inline"`
+		// Length of time before health checking is activated.  In seconds.
+		InitialDelaySeconds int `json:"initialDelaySeconds,omitempty"`
+		// Length of time before health checking times out.  In seconds.
+		TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
+		// How often (in seconds) to perform the probe.
+		PeriodSeconds int `json:"periodSeconds,omitempty"`
+		// Minimum consecutive successes for the probe to be considered successful after having failed.
+		// Must be 1 for liveness.
+		SuccessThreshold int `json:"successThreshold,omitempty"`
+		// Minimum consecutive failures for the probe to be considered failed after having succeeded.
+		FailureThreshold int `json:"failureThreshold,omitempty"`
+	}
+
+	// Handler defines a specific action that should be taken TODO: pass structured data to these actions, and document that data here.
+	Handler struct {
+		// One and only one of the following should be specified.
+		// Exec specifies the action to take.
+		Exec *ExecAction `json:"exec,omitempty"`
+		// HTTPGet specifies the http request to perform.
+		HTTPGet *HTTPGetAction `json:"httpGet,omitempty"`
+		// TCPSocket specifies an action involving a TCP port.
+		// TODO: implement a realistic TCP lifecycle hook
+		TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"`
+	}
+
+	// ExecAction describes a "run in container" action.
+	ExecAction struct {
+		// Command is the command line to execute inside the container, the working directory for the
+		// command  is root ('/') in the container's filesystem.  The command is simply exec'd, it is
+		// not run inside a shell, so traditional shell instructions ('|', etc) won't work.  To use
+		// a shell, you need to explicitly call out to that shell.
+		Command []string `json:"command,omitempty"`
+	}
+
+	// HTTPGetAction describes an action based on HTTP Get requests.
+	HTTPGetAction struct {
+		// Optional: Path to access on the HTTP server.
+		Path string `json:"path,omitempty"`
+		// Required: Name or number of the port to access on the container.
+		Port intstr.IntOrString `json:"port,omitempty"`
+		// Optional: Host name to connect to, defaults to the pod IP. You
+		// probably want to set "Host" in httpHeaders instead.
+		Host string `json:"host,omitempty"`
+		// Optional: Scheme to use for connecting to the host, defaults to HTTP.
+		Scheme URIScheme `json:"scheme,omitempty"`
+		// Optional: Custom headers to set in the request. HTTP allows repeated headers.
+		HTTPHeaders []HTTPHeader `json:"httpHeaders,omitempty"`
+	}
+
+	// HTTPHeader describes a custom header to be used in HTTP probes
+	HTTPHeader struct {
+		// The header field name
+		Name string `json:"name"`
+		// The header field value
+		Value string `json:"value"`
+	}
+
+	// ResourceRequirements describes the compute resource requirements.
+	ResourceRequirements struct {
+		// Limits describes the maximum amount of compute resources allowed.
+		Limits ResourceList `json:"limits,omitempty"`
+		// Requests describes the minimum amount of compute resources required.
+		// If Request is omitted for a container, it defaults to Limits if that is explicitly specified,
+		// otherwise to an implementation-defined value
+		Requests ResourceList `json:"requests,omitempty"`
+	}
+
+	// ResourceList is a set of (resource name, quantity) pairs.
+	ResourceList map[ResourceName]string
+
+	// ResourceName is the name identifying various resources in a ResourceList.
+	ResourceName string
+
+	// TCPSocketAction describes an action based on opening a socket
+	TCPSocketAction struct {
+		// Required: Port to connect to.
+		Port intstr.IntOrString `json:"port,omitempty"`
+	}
+
+	// Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.
+	Lifecycle struct {
+		// PostStart is called immediately after a container is created.  If the handler fails, the container
+		// is terminated and restarted.
+		PostStart *Handler `json:"postStart,omitempty"`
+		// PreStop is called immediately before a container is terminated.  The reason for termination is
+		// passed to the handler.  Regardless of the outcome of the handler, the container is eventually terminated.
+		PreStop *Handler `json:"preStop,omitempty"`
+	}
+
+	// PullPolicy describes a policy for if/when to pull a container image
+	PullPolicy string
+
+	// PodPhase is a label for the condition of a pod at the current time.
+	PodPhase string
+
+	// ContainerStatus is the status of a single container within a pod.
+	ContainerStatus struct {
+		// Each container in a pod must have a unique name.
+		Name                 string          `json:"name"`
+		State                *ContainerState `json:"state,omitempty"`
+		LastTerminationState *ContainerState `json:"lastState,omitempty"`
+		// Ready specifies whether the container has passed its readiness check.
+		Ready bool `json:"ready"`
+		// Note that this is calculated from dead containers.  But those containers are subject to
+		// garbage collection.  This value will get capped at 5 by GC.
+		RestartCount int    `json:"restartCount"`
+		Image        string `json:"image"`
+		ImageID      string `json:"imageID"`
+		ContainerID  string `json:"containerID,omitempty"`
+	}
+
+	// ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.
+	ContainerState struct {
+		Waiting    *ContainerStateWaiting    `json:"waiting,omitempty"`
+		Running    *ContainerStateRunning    `json:"running,omitempty"`
+		Terminated *ContainerStateTerminated `json:"terminated,omitempty"`
+	}
+
+	ContainerStateWaiting struct {
+		// A brief CamelCase string indicating details about why the container is in waiting state.
+		Reason string `json:"reason,omitempty"`
+		// A human-readable message indicating details about why the container is in waiting state.
+		Message string `json:"message,omitempty"`
+	}
+
+	ContainerStateRunning struct {
+		StartedAt Time `json:"startedAt,omitempty"`
+	}
+
+	ContainerStateTerminated struct {
+		ExitCode    int    `json:"exitCode"`
+		Signal      int    `json:"signal,omitempty"`
+		Reason      string `json:"reason,omitempty"`
+		Message     string `json:"message,omitempty"`
+		StartedAt   Time   `json:"startedAt,omitempty"`
+		FinishedAt  Time   `json:"finishedAt,omitempty"`
+		ContainerID string `json:"containerID,omitempty"`
+	}
+)

--- a/deps/github.com/YakLabs/k8s-client/replicaset.go
+++ b/deps/github.com/YakLabs/k8s-client/replicaset.go
@@ -1,0 +1,71 @@
+package client
+
+type (
+	// ReplicaSetInterface has methods to work with ReplicaSet resources.
+	ReplicaSetInterface interface {
+		CreateReplicaSet(namespace string, item *ReplicaSet) (*ReplicaSet, error)
+		GetReplicaSet(namespace, name string) (result *ReplicaSet, err error)
+		ListReplicaSets(namespace string, opts *ListOptions) (*ReplicaSetList, error)
+		DeleteReplicaSet(namespace, name string) error
+		UpdateReplicaSet(namespace string, item *ReplicaSet) (*ReplicaSet, error)
+	}
+
+	// ReplicaSetList is a collection of ReplicaSets.
+	ReplicaSetList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+		Items    []ReplicaSet `json:"items"`
+	}
+
+	// ReplicaSet represents the configuration of a replica set.
+	ReplicaSet struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// Spec defines the desired behavior of this ReplicaSet.
+		Spec *ReplicaSetSpec `json:"spec,omitempty"`
+
+		// Status is the current status of this ReplicaSet. This data may be
+		// out of date by some window of time.
+		Status *ReplicaSetStatus `json:"status,omitempty"`
+	}
+
+	// ReplicaSetStatus represents the current status of a ReplicaSet.
+	ReplicaSetStatus struct {
+		// Replicas is the number of actual replicas.
+		Replicas int32 `json:"replicas"`
+
+		// The number of pods that have labels matching the labels of the pod template of the replicaset.
+		FullyLabeledReplicas int32 `json:"fullyLabeledReplicas,omitempty"`
+
+		// ObservedGeneration is the most recent generation observed by the controller.
+		ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	}
+
+	// ReplicaSetSpec is the specification of a replication set.
+	ReplicaSetSpec struct {
+		// Replicas is the number of desired replicas.
+		Replicas int32 `json:"replicas"`
+
+		// Selector is a label query over pods that should match the replica count.
+		// Must match in order to be controlled.
+		// If empty, defaulted to labels on pod template.
+		// More info: http://releases.k8s.io/release-1.3/docs/user-guide/labels.md#label-selectors
+		Selector *LabelSelector `json:"selector,omitempty"`
+
+		// Template is the object that describes the pod that will be created if
+		// insufficient replicas are detected.
+		Template *PodTemplateSpec `json:"template,omitempty"`
+	}
+)
+
+// NewReplicaSet creates a new ReplicaSet struct
+func NewReplicaSet(namespace, name string) *ReplicaSet {
+	return &ReplicaSet{
+		TypeMeta:   NewTypeMeta("ReplicaSet", "extensions/v1beta1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Spec: &ReplicaSetSpec{
+			Template: NewPodTemplateSpec("", ""),
+		},
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/secret.go
+++ b/deps/github.com/YakLabs/k8s-client/secret.go
@@ -1,0 +1,42 @@
+package client
+
+type (
+	// SecretInterface has methods to work with Secret resources.
+	SecretInterface interface {
+		CreateSecret(namespace string, item *Secret) (*Secret, error)
+		GetSecret(namespace, name string) (result *Secret, err error)
+		ListSecrets(namespace string, opts *ListOptions) (*SecretList, error)
+		DeleteSecret(namespace, name string) error
+		UpdateSecret(namespace string, item *Secret) (*Secret, error)
+	}
+
+	// SecretType is the type of secret.
+	SecretType string
+
+	// Secret holds secret data of a certain type.
+	Secret struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+		Data       map[string][]byte `json:"data,omitempty"`
+
+		// Used to facilitate programmatic handling of secret data.
+		Type SecretType `json:"type,omitempty"`
+	}
+
+	// SecretList holds a list of secrets.
+	SecretList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		Items []Secret `json:"items"`
+	}
+)
+
+// NewSecret creates a new Secret struct
+func NewSecret(namespace, name string) *Secret {
+	return &Secret{
+		TypeMeta:   NewTypeMeta("Secret", "v1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Data:       make(map[string][]byte),
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/service.go
+++ b/deps/github.com/YakLabs/k8s-client/service.go
@@ -1,0 +1,164 @@
+package client
+
+import "github.com/YakLabs/k8s-client/intstr"
+
+const (
+	// ServiceTypeClusterIP means a service will only be accessible inside the
+	// cluster, via the ClusterIP.
+	ServiceTypeClusterIP ServiceType = "ClusterIP"
+
+	// ServiceTypeNodePort means a service will be exposed on one port of
+	// every node, in addition to 'ClusterIP' type.
+	ServiceTypeNodePort ServiceType = "NodePort"
+
+	// ServiceTypeLoadBalancer means a service will be exposed via an
+	// external load balancer (if the cloud provider supports it), in addition
+	// to 'NodePort' type.
+	ServiceTypeLoadBalancer ServiceType = "LoadBalancer"
+
+	// ServiceAffinityClientIP is the Client IP based.
+	ServiceAffinityClientIP ServiceAffinity = "ClientIP"
+
+	// ServiceAffinityNone - no session affinity.
+	ServiceAffinityNone ServiceAffinity = "None"
+)
+
+type (
+	// ServiceInterface has methods to work with Service resources.
+	ServiceInterface interface {
+		CreateService(namespace string, item *Service) (*Service, error)
+		GetService(namespace, name string) (result *Service, err error)
+		ListServices(namespace string, opts *ListOptions) (*ServiceList, error)
+		DeleteService(namespace, name string) error
+		UpdateService(namespace string, item *Service) (*Service, error)
+	}
+
+	// Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
+	Service struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// Spec defines the behavior of a service
+		Spec *ServiceSpec `json:"spec,omitempty"`
+
+		// Status represents the current status of a service.
+		Status *ServiceStatus `json:"status,omitempty"`
+	}
+
+	// ServiceList holds a list of services.
+	ServiceList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+
+		Items []Service `json:"items"`
+	}
+
+	// ServiceStatus represents the current status of a service
+	ServiceStatus struct {
+		// LoadBalancer contains the current status of the load-balancer,
+		// if one is present.
+		LoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
+	}
+
+	// LoadBalancerStatus represents the status of a load-balancer
+	LoadBalancerStatus struct {
+		// Ingress is a list containing ingress points for the load-balancer;
+		// traffic intended for the service should be sent to these ingress points.
+		Ingress []LoadBalancerIngress `json:"ingress,omitempty"`
+	}
+
+	// LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.
+	LoadBalancerIngress struct {
+		// IP is set for load-balancer ingress points that are IP based
+		// (typically GCE or OpenStack load-balancers)
+		IP string `json:"ip,omitempty"`
+
+		// Hostname is set for load-balancer ingress points that are DNS based
+		// (typically AWS load-balancers)
+		Hostname string `json:"hostname,omitempty"`
+	}
+
+	// ServiceType describes ingress methods for a service
+	ServiceType string
+	// ServiceAffinity is the type of affinity for the service
+	ServiceAffinity string
+
+	// ServiceSpec describes the attributes that a user creates on a service
+	ServiceSpec struct {
+		// Type determines how the service will be exposed.  Valid options: ClusterIP, NodePort, LoadBalancer
+		Type ServiceType `json:"type,omitempty"`
+
+		// Required: The list of ports that are exposed by this service.
+		Ports []ServicePort `json:"ports"`
+
+		// This service will route traffic to pods having labels matching this selector. If empty or not present,
+		// the service is assumed to have endpoints set by an external process and Kubernetes will not modify
+		// those endpoints.
+		Selector map[string]string `json:"selector"`
+
+		// ClusterIP is usually assigned by the master.  If specified by the user
+		// we will try to respect it or else fail the request.  This field can
+		// not be changed by updates.
+		// Valid values are None, empty string (""), or a valid IP address
+		// None can be specified for headless services when proxying is not required
+		ClusterIP string `json:"clusterIP,omitempty"`
+
+		// ExternalIPs are used by external load balancers, or can be set by
+		// users to handle external traffic that arrives at a node.
+		ExternalIPs []string `json:"externalIPs,omitempty"`
+
+		// Only applies to Service Type: LoadBalancer
+		// LoadBalancer will get created with the IP specified in this field.
+		// This feature depends on whether the underlying cloud-provider supports specifying
+		// the loadBalancerIP when a load balancer is created.
+		// This field will be ignored if the cloud-provider does not support the feature.
+		LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
+
+		// Optional: Supports "ClientIP" and "None".  Used to maintain session affinity.
+		SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty"`
+
+		// Optional: If specified and supported by the platform, this will restrict traffic through the cloud-provider
+		// load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+		// cloud-provider does not support the feature."
+		LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
+	}
+
+	// ServicePort is a single exposed port.
+	ServicePort struct {
+		// Optional if only one ServicePort is defined on this service: The
+		// name of this port within the service.  This must be a DNS_LABEL.
+		// All ports within a ServiceSpec must have unique names.  This maps to
+		// the 'Name' field in EndpointPort objects.
+		Name string `json:"name"`
+
+		// The IP protocol for this port.  Supports "TCP" and "UDP".
+		Protocol Protocol `json:"protocol"`
+
+		// The port that will be exposed on the service.
+		Port int32 `json:"port"`
+
+		// Optional: The target port on pods selected by this service.  If this
+		// is a string, it will be looked up as a named port in the target
+		// Pod's container ports.  If this is not specified, the value
+		// of the 'port' field is used (an identity map).
+		// This field is ignored for services with clusterIP=None, and should be
+		// omitted or set equal to the 'port' field.
+		TargetPort intstr.IntOrString `json:"targetPort"`
+
+		// The port on each node on which this service is exposed.
+		// Default is to auto-allocate a port if the ServiceType of this Service requires one.
+		NodePort int32 `json:"nodePort"`
+	}
+)
+
+// NewService creates a new service struct
+func NewService(namespace, name string) *Service {
+	return &Service{
+		TypeMeta:   NewTypeMeta("Service", "v1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+		Spec: &ServiceSpec{
+			Ports:    make([]ServicePort, 0),
+			Selector: make(map[string]string),
+		},
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/serviceaccount.go
+++ b/deps/github.com/YakLabs/k8s-client/serviceaccount.go
@@ -1,0 +1,41 @@
+package client
+
+type (
+	// ServiceAccountInterface is the interface that defines ServiceAccount functions.
+	ServiceAccountInterface interface {
+		CreateServiceAccount(namespace string, item *ServiceAccount) (*ServiceAccount, error)
+		GetServiceAccount(namespace, name string) (result *ServiceAccount, err error)
+		ListServiceAccounts(namespace string, opts *ListOptions) (*ServiceAccountList, error)
+		DeleteServiceAccount(namepsace, name string) error
+		UpdateServiceAccount(namespace string, item *ServiceAccount) (*ServiceAccount, error)
+	}
+
+	// ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
+	ServiceAccount struct {
+		TypeMeta   `json:",inline"`
+		ObjectMeta `json:"metadata,omitempty"`
+
+		// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount
+		Secrets []ObjectReference `json:"secrets"`
+
+		// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
+		// in pods that reference this ServiceAccount.  ImagePullSecrets are distinct from Secrets because Secrets
+		// can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet.
+		ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	}
+
+	// ServiceAccountList is a list of ServiceAccount objects
+	ServiceAccountList struct {
+		TypeMeta `json:",inline"`
+		ListMeta `json:"metadata,omitempty"`
+		Items    []ServiceAccount `json:"items"`
+	}
+)
+
+// NewServiceAccount creates a new ServiceAccount struct
+func NewServiceAccount(namespace, name string) *ServiceAccount {
+	return &ServiceAccount{
+		TypeMeta:   NewTypeMeta("ServiceAccount", "v1"),
+		ObjectMeta: NewObjectMeta(namespace, name),
+	}
+}

--- a/deps/github.com/YakLabs/k8s-client/status.go
+++ b/deps/github.com/YakLabs/k8s-client/status.go
@@ -1,0 +1,119 @@
+package client
+
+import "fmt"
+
+// Values of Status.Status
+const (
+	StatusSuccess = "Success"
+	StatusFailure = "Failure"
+)
+
+const (
+	// CauseTypeFieldValueNotFound is used to report failure to find a requested value
+	// (e.g. looking up an ID).
+	CauseTypeFieldValueNotFound CauseType = "FieldValueNotFound"
+	// CauseTypeFieldValueRequired is used to report required values that are not
+	// provided (e.g. empty strings, null values, or empty arrays).
+	CauseTypeFieldValueRequired CauseType = "FieldValueRequired"
+	// CauseTypeFieldValueDuplicate is used to report collisions of values that must be
+	// unique (e.g. unique IDs).
+	CauseTypeFieldValueDuplicate CauseType = "FieldValueDuplicate"
+	// CauseTypeFieldValueInvalid is used to report malformed values (e.g. failed regex
+	// match).
+	CauseTypeFieldValueInvalid CauseType = "FieldValueInvalid"
+	// CauseTypeFieldValueNotSupported is used to report valid (as per formatting rules)
+	// values that can not be handled (e.g. an enumerated string).
+	CauseTypeFieldValueNotSupported CauseType = "FieldValueNotSupported"
+	// CauseTypeUnexpectedServerResponse is used to report when the server responded to the client
+	// without the expected return type. The presence of this cause indicates the error may be
+	// due to an intervening proxy or the server software malfunctioning.
+	CauseTypeUnexpectedServerResponse CauseType = "UnexpectedServerResponse"
+)
+
+type (
+
+	// StatusReason is an enumeration of possible failure causes.  Each StatusReason
+	// must map to a single HTTP status code, but multiple reasons may map
+	// to the same HTTP status code.
+	StatusReason string
+
+	// Status is a return value for calls that don't return other objects.
+	Status struct {
+		TypeMeta `json:",inline"`
+		// Standard list metadata.
+		// More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds
+		ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+		// Status of the operation.
+		// One of: "Success" or "Failure".
+		// More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#spec-and-status
+		Status string `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
+		// A human-readable description of the status of this operation.
+		Message string `json:"message,omitempty" protobuf:"bytes,3,opt,name=message"`
+		// A machine-readable description of why this operation is in the
+		// "Failure" status. If this value is empty there
+		// is no information available. A Reason clarifies an HTTP status
+		// code but does not override it.
+		Reason StatusReason `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason,casttype=StatusReason"`
+		// Extended data associated with the reason.  Each reason may define its
+		// own extended details. This field is optional and the data returned
+		// is not guaranteed to conform to any schema except that defined by
+		// the reason type.
+		Details *StatusDetails `json:"details,omitempty" protobuf:"bytes,5,opt,name=details"`
+		// Suggested HTTP return code for this status, 0 if not set.
+		Code int32 `json:"code,omitempty" protobuf:"varint,6,opt,name=code"`
+	}
+
+	// StatusDetails is a set of additional properties that MAY be set by the
+	// server to provide additional information about a response. The Reason
+	// field of a Status object defines what attributes will be set. Clients
+	// must ignore fields that do not match the defined type of each attribute,
+	// and should assume that any attribute may be empty, invalid, or under
+	// defined.
+	StatusDetails struct {
+		// The name attribute of the resource associated with the status StatusReason
+		// (when there is a single name which can be described).
+		Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+		// The group attribute of the resource associated with the status StatusReason.
+		Group string `json:"group,omitempty" protobuf:"bytes,2,opt,name=group"`
+		// The kind attribute of the resource associated with the status StatusReason.
+		// On some operations may differ from the requested resource Kind.
+		// More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds
+		Kind string `json:"kind,omitempty" protobuf:"bytes,3,opt,name=kind"`
+		// The Causes array includes more details associated with the StatusReason
+		// failure. Not all StatusReasons may provide detailed causes.
+		Causes []StatusCause `json:"causes,omitempty" protobuf:"bytes,4,rep,name=causes"`
+		// If specified, the time in seconds before the operation should be retried.
+		RetryAfterSeconds int32 `json:"retryAfterSeconds,omitempty" protobuf:"varint,5,opt,name=retryAfterSeconds"`
+	}
+
+	// StatusCause provides more information about an api.Status failure, including
+	// cases when multiple errors are encountered.
+	StatusCause struct {
+		// A machine-readable description of the cause of the error. If this value is
+		// empty there is no information available.
+		Type CauseType `json:"reason,omitempty" protobuf:"bytes,1,opt,name=reason,casttype=CauseType"`
+		// A human-readable description of the cause of the error.  This field may be
+		// presented as-is to a reader.
+		Message string `json:"message,omitempty" protobuf:"bytes,2,opt,name=message"`
+		// The field of the resource that has caused this error, as named by its JSON
+		// serialization. May include dot and postfix notation for nested attributes.
+		// Arrays are zero-indexed.  Fields may appear more than once in an array of
+		// causes due to fields having multiple errors.
+		// Optional.
+		//
+		// Examples:
+		//   "name" - the field "name" on the current resource
+		//   "items[0].name" - the field "name" on the first array entry in "items"
+		Field string `json:"field,omitempty" protobuf:"bytes,3,opt,name=field"`
+	}
+
+	// CauseType is a machine readable value providing more detail about what
+	// occurred in a status response. An operation may have multiple causes for a
+	// status (whether Failure or Success).
+	CauseType string
+)
+
+func (s *Status) Error() string {
+	return fmt.Sprintf("%d: %s", s.Code, s.Message)
+}

--- a/deps/github.com/YakLabs/k8s-client/time.go
+++ b/deps/github.com/YakLabs/k8s-client/time.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type (
+	Time struct {
+		time.Time
+	}
+)
+
+// Date returns the Time corresponding to the supplied parameters
+// by wrapping time.Date.
+func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {
+	return Time{time.Date(year, month, day, hour, min, sec, nsec, loc)}
+}
+
+// Now returns the current local time.
+func Now() Time {
+	return Time{time.Now()}
+}
+
+// IsZero returns true if the value is nil or time is zero.
+func (t *Time) IsZero() bool {
+	if t == nil {
+		return true
+	}
+	return t.Time.IsZero()
+}
+
+// Before reports whether the time instant t is before u.
+func (t Time) Before(u Time) bool {
+	return t.Time.Before(u.Time)
+}
+
+// Equal reports whether the time instant t is equal to u.
+func (t Time) Equal(u Time) bool {
+	return t.Time.Equal(u.Time)
+}
+
+// Unix returns the local time corresponding to the given Unix time
+// by wrapping time.Unix.
+func Unix(sec int64, nsec int64) Time {
+	return Time{time.Unix(sec, nsec)}
+}
+
+// Rfc3339Copy returns a copy of the Time at second-level precision.
+func (t Time) Rfc3339Copy() Time {
+	copied, _ := time.Parse(time.RFC3339, t.Format(time.RFC3339))
+	return Time{copied}
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (t *Time) UnmarshalJSON(b []byte) error {
+	if len(b) == 4 && string(b) == "null" {
+		t.Time = time.Time{}
+		return nil
+	}
+
+	var str string
+	json.Unmarshal(b, &str)
+
+	pt, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return err
+	}
+
+	t.Time = pt.Local()
+	return nil
+}
+
+// UnmarshalQueryParameter converts from a URL query parameter value to an object
+func (t *Time) UnmarshalQueryParameter(str string) error {
+	if len(str) == 0 {
+		t.Time = time.Time{}
+		return nil
+	}
+	// Tolerate requests from older clients that used JSON serialization to build query params
+	if len(str) == 4 && str == "null" {
+		t.Time = time.Time{}
+		return nil
+	}
+
+	pt, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return err
+	}
+
+	t.Time = pt.Local()
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (t Time) MarshalJSON() ([]byte, error) {
+	if t.IsZero() {
+		// Encode unset/nil objects as JSON's "null".
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(t.UTC().Format(time.RFC3339))
+}
+
+// MarshalQueryParameter converts to a URL query parameter value
+func (t Time) MarshalQueryParameter() (string, error) {
+	if t.IsZero() {
+		// Encode unset/nil objects as an empty string
+		return "", nil
+	}
+
+	return t.UTC().Format(time.RFC3339), nil
+}

--- a/deps/github.com/google/gofuzz/.travis.yml
+++ b/deps/github.com/google/gofuzz/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+go:
+  - 1.4
+  - 1.3
+  - 1.2
+  - tip
+
+install:
+  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+
+script:
+  - go test -cover

--- a/deps/github.com/google/gofuzz/CONTRIBUTING.md
+++ b/deps/github.com/google/gofuzz/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# How to contribute #
+
+We'd love to accept your patches and contributions to this project.  There are
+a just a few small guidelines you need to follow.
+
+
+## Contributor License Agreement ##
+
+Contributions to any Google project must be accompanied by a Contributor
+License Agreement.  This is not a copyright **assignment**, it simply gives
+Google permission to use and redistribute your contributions as part of the
+project.
+
+  * If you are an individual writing original source code and you're sure you
+    own the intellectual property, then you'll need to sign an [individual
+    CLA][].
+
+  * If you work for a company that wants to allow you to contribute your work,
+    then you'll need to sign a [corporate CLA][].
+
+You generally only need to submit a CLA once, so if you've already submitted
+one (even if it was for a different project), you probably don't need to do it
+again.
+
+[individual CLA]: https://developers.google.com/open-source/cla/individual
+[corporate CLA]: https://developers.google.com/open-source/cla/corporate
+
+
+## Submitting a patch ##
+
+  1. It's generally best to start by opening a new issue describing the bug or
+     feature you're intending to fix.  Even if you think it's relatively minor,
+     it's helpful to know what people are working on.  Mention in the initial
+     issue that you are planning to work on that bug or feature so that it can
+     be assigned to you.
+
+  1. Follow the normal process of [forking][] the project, and setup a new
+     branch to work in.  It's important that each group of changes be done in
+     separate branches in order to ensure that a pull request only includes the
+     commits related to that bug or feature.
+
+  1. Go makes it very simple to ensure properly formatted code, so always run
+     `go fmt` on your code before committing it.  You should also run
+     [golint][] over your code.  As noted in the [golint readme][], it's not
+     strictly necessary that your code be completely "lint-free", but this will
+     help you find common style issues.
+
+  1. Any significant changes should almost always be accompanied by tests.  The
+     project already has good test coverage, so look at some of the existing
+     tests if you're unsure how to go about it.  [gocov][] and [gocov-html][]
+     are invaluable tools for seeing which parts of your code aren't being
+     exercised by your tests.
+
+  1. Do your best to have [well-formed commit messages][] for each change.
+     This provides consistency throughout the project, and ensures that commit
+     messages are able to be formatted properly by various git tools.
+
+  1. Finally, push the commits to your fork and submit a [pull request][].
+
+[forking]: https://help.github.com/articles/fork-a-repo
+[golint]: https://github.com/golang/lint
+[golint readme]: https://github.com/golang/lint/blob/master/README
+[gocov]: https://github.com/axw/gocov
+[gocov-html]: https://github.com/matm/gocov-html
+[well-formed commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[squash]: http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits
+[pull request]: https://help.github.com/articles/creating-a-pull-request

--- a/deps/github.com/google/gofuzz/LICENSE
+++ b/deps/github.com/google/gofuzz/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/deps/github.com/google/gofuzz/README.md
+++ b/deps/github.com/google/gofuzz/README.md
@@ -1,0 +1,71 @@
+gofuzz
+======
+
+gofuzz is a library for populating go objects with random values.
+
+[![GoDoc](https://godoc.org/github.com/google/gofuzz?status.png)](https://godoc.org/github.com/google/gofuzz)
+[![Travis](https://travis-ci.org/google/gofuzz.svg?branch=master)](https://travis-ci.org/google/gofuzz)
+
+This is useful for testing:
+
+* Do your project's objects really serialize/unserialize correctly in all cases?
+* Is there an incorrectly formatted object that will cause your project to panic?
+
+Import with ```import "github.com/google/gofuzz"```
+
+You can use it on single variables:
+```go
+f := fuzz.New()
+var myInt int
+f.Fuzz(&myInt) // myInt gets a random value.
+```
+
+You can use it on maps:
+```go
+f := fuzz.New().NilChance(0).NumElements(1, 1)
+var myMap map[ComplexKeyType]string
+f.Fuzz(&myMap) // myMap will have exactly one element.
+```
+
+Customize the chance of getting a nil pointer:
+```go
+f := fuzz.New().NilChance(.5)
+var fancyStruct struct {
+  A, B, C, D *string
+}
+f.Fuzz(&fancyStruct) // About half the pointers should be set.
+```
+
+You can even customize the randomization completely if needed:
+```go
+type MyEnum string
+const (
+        A MyEnum = "A"
+        B MyEnum = "B"
+)
+type MyInfo struct {
+        Type MyEnum
+        AInfo *string
+        BInfo *string
+}
+
+f := fuzz.New().NilChance(0).Funcs(
+        func(e *MyInfo, c fuzz.Continue) {
+                switch c.Intn(2) {
+                case 0:
+                        e.Type = A
+                        c.Fuzz(&e.AInfo)
+                case 1:
+                        e.Type = B
+                        c.Fuzz(&e.BInfo)
+                }
+        },
+)
+
+var myObject MyInfo
+f.Fuzz(&myObject) // Type will correspond to whether A or B info is set.
+```
+
+See more examples in ```example_test.go```.
+
+Happy testing!

--- a/deps/github.com/google/gofuzz/doc.go
+++ b/deps/github.com/google/gofuzz/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fuzz is a library for populating go objects with random values.
+package fuzz

--- a/deps/github.com/google/gofuzz/example_test.go
+++ b/deps/github.com/google/gofuzz/example_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzz_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+
+	"github.com/google/gofuzz"
+)
+
+func ExampleSimple() {
+	type MyType struct {
+		A string
+		B string
+		C int
+		D struct {
+			E float64
+		}
+	}
+
+	f := fuzz.New()
+	object := MyType{}
+
+	uniqueObjects := map[MyType]int{}
+
+	for i := 0; i < 1000; i++ {
+		f.Fuzz(&object)
+		uniqueObjects[object]++
+	}
+	fmt.Printf("Got %v unique objects.\n", len(uniqueObjects))
+	// Output:
+	// Got 1000 unique objects.
+}
+
+func ExampleCustom() {
+	type MyType struct {
+		A int
+		B string
+	}
+
+	counter := 0
+	f := fuzz.New().Funcs(
+		func(i *int, c fuzz.Continue) {
+			*i = counter
+			counter++
+		},
+	)
+	object := MyType{}
+
+	uniqueObjects := map[MyType]int{}
+
+	for i := 0; i < 100; i++ {
+		f.Fuzz(&object)
+		if object.A != i {
+			fmt.Printf("Unexpected value: %#v\n", object)
+		}
+		uniqueObjects[object]++
+	}
+	fmt.Printf("Got %v unique objects.\n", len(uniqueObjects))
+	// Output:
+	// Got 100 unique objects.
+}
+
+func ExampleComplex() {
+	type OtherType struct {
+		A string
+		B string
+	}
+	type MyType struct {
+		Pointer             *OtherType
+		Map                 map[string]OtherType
+		PointerMap          *map[string]OtherType
+		Slice               []OtherType
+		SlicePointer        []*OtherType
+		PointerSlicePointer *[]*OtherType
+	}
+
+	f := fuzz.New().RandSource(rand.NewSource(0)).NilChance(0).NumElements(1, 1).Funcs(
+		func(o *OtherType, c fuzz.Continue) {
+			o.A = "Foo"
+			o.B = "Bar"
+		},
+		func(op **OtherType, c fuzz.Continue) {
+			*op = &OtherType{"A", "B"}
+		},
+		func(m map[string]OtherType, c fuzz.Continue) {
+			m["Works Because"] = OtherType{
+				"Fuzzer",
+				"Preallocated",
+			}
+		},
+	)
+	object := MyType{}
+	f.Fuzz(&object)
+	bytes, err := json.MarshalIndent(&object, "", "    ")
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
+	fmt.Printf("%s\n", string(bytes))
+	// Output:
+	// {
+	//     "Pointer": {
+	//         "A": "A",
+	//         "B": "B"
+	//     },
+	//     "Map": {
+	//         "Works Because": {
+	//             "A": "Fuzzer",
+	//             "B": "Preallocated"
+	//         }
+	//     },
+	//     "PointerMap": {
+	//         "Works Because": {
+	//             "A": "Fuzzer",
+	//             "B": "Preallocated"
+	//         }
+	//     },
+	//     "Slice": [
+	//         {
+	//             "A": "Foo",
+	//             "B": "Bar"
+	//         }
+	//     ],
+	//     "SlicePointer": [
+	//         {
+	//             "A": "A",
+	//             "B": "B"
+	//         }
+	//     ],
+	//     "PointerSlicePointer": [
+	//         {
+	//             "A": "A",
+	//             "B": "B"
+	//         }
+	//     ]
+	// }
+}
+
+func ExampleMap() {
+	f := fuzz.New().NilChance(0).NumElements(1, 1)
+	var myMap map[struct{ A, B, C int }]string
+	f.Fuzz(&myMap)
+	fmt.Printf("myMap has %v element(s).\n", len(myMap))
+	// Output:
+	// myMap has 1 element(s).
+}
+
+func ExampleSingle() {
+	f := fuzz.New()
+	var i int
+	f.Fuzz(&i)
+
+	// Technically, we'd expect this to fail one out of 2 billion attempts...
+	fmt.Printf("(i == 0) == %v", i == 0)
+	// Output:
+	// (i == 0) == false
+}
+
+func ExampleEnum() {
+	type MyEnum string
+	const (
+		A MyEnum = "A"
+		B MyEnum = "B"
+	)
+	type MyInfo struct {
+		Type  MyEnum
+		AInfo *string
+		BInfo *string
+	}
+
+	f := fuzz.New().NilChance(0).Funcs(
+		func(e *MyInfo, c fuzz.Continue) {
+			// Note c's embedded Rand allows for direct use.
+			// We could also use c.RandBool() here.
+			switch c.Intn(2) {
+			case 0:
+				e.Type = A
+				c.Fuzz(&e.AInfo)
+			case 1:
+				e.Type = B
+				c.Fuzz(&e.BInfo)
+			}
+		},
+	)
+
+	for i := 0; i < 100; i++ {
+		var myObject MyInfo
+		f.Fuzz(&myObject)
+		switch myObject.Type {
+		case A:
+			if myObject.AInfo == nil {
+				fmt.Println("AInfo should have been set!")
+			}
+			if myObject.BInfo != nil {
+				fmt.Println("BInfo should NOT have been set!")
+			}
+		case B:
+			if myObject.BInfo == nil {
+				fmt.Println("BInfo should have been set!")
+			}
+			if myObject.AInfo != nil {
+				fmt.Println("AInfo should NOT have been set!")
+			}
+		default:
+			fmt.Println("Invalid enum value!")
+		}
+	}
+	// Output:
+}

--- a/deps/github.com/google/gofuzz/fuzz.go
+++ b/deps/github.com/google/gofuzz/fuzz.go
@@ -1,0 +1,453 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzz
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"time"
+)
+
+// fuzzFuncMap is a map from a type to a fuzzFunc that handles that type.
+type fuzzFuncMap map[reflect.Type]reflect.Value
+
+// Fuzzer knows how to fill any object with random fields.
+type Fuzzer struct {
+	fuzzFuncs        fuzzFuncMap
+	defaultFuzzFuncs fuzzFuncMap
+	r                *rand.Rand
+	nilChance        float64
+	minElements      int
+	maxElements      int
+}
+
+// New returns a new Fuzzer. Customize your Fuzzer further by calling Funcs,
+// RandSource, NilChance, or NumElements in any order.
+func New() *Fuzzer {
+	f := &Fuzzer{
+		defaultFuzzFuncs: fuzzFuncMap{
+			reflect.TypeOf(&time.Time{}): reflect.ValueOf(fuzzTime),
+		},
+
+		fuzzFuncs:   fuzzFuncMap{},
+		r:           rand.New(rand.NewSource(time.Now().UnixNano())),
+		nilChance:   .2,
+		minElements: 1,
+		maxElements: 10,
+	}
+	return f
+}
+
+// Funcs adds each entry in fuzzFuncs as a custom fuzzing function.
+//
+// Each entry in fuzzFuncs must be a function taking two parameters.
+// The first parameter must be a pointer or map. It is the variable that
+// function will fill with random data. The second parameter must be a
+// fuzz.Continue, which will provide a source of randomness and a way
+// to automatically continue fuzzing smaller pieces of the first parameter.
+//
+// These functions are called sensibly, e.g., if you wanted custom string
+// fuzzing, the function `func(s *string, c fuzz.Continue)` would get
+// called and passed the address of strings. Maps and pointers will always
+// be made/new'd for you, ignoring the NilChange option. For slices, it
+// doesn't make much sense to  pre-create them--Fuzzer doesn't know how
+// long you want your slice--so take a pointer to a slice, and make it
+// yourself. (If you don't want your map/pointer type pre-made, take a
+// pointer to it, and make it yourself.) See the examples for a range of
+// custom functions.
+func (f *Fuzzer) Funcs(fuzzFuncs ...interface{}) *Fuzzer {
+	for i := range fuzzFuncs {
+		v := reflect.ValueOf(fuzzFuncs[i])
+		if v.Kind() != reflect.Func {
+			panic("Need only funcs!")
+		}
+		t := v.Type()
+		if t.NumIn() != 2 || t.NumOut() != 0 {
+			panic("Need 2 in and 0 out params!")
+		}
+		argT := t.In(0)
+		switch argT.Kind() {
+		case reflect.Ptr, reflect.Map:
+		default:
+			panic("fuzzFunc must take pointer or map type")
+		}
+		if t.In(1) != reflect.TypeOf(Continue{}) {
+			panic("fuzzFunc's second parameter must be type fuzz.Continue")
+		}
+		f.fuzzFuncs[argT] = v
+	}
+	return f
+}
+
+// RandSource causes f to get values from the given source of randomness.
+// Use if you want deterministic fuzzing.
+func (f *Fuzzer) RandSource(s rand.Source) *Fuzzer {
+	f.r = rand.New(s)
+	return f
+}
+
+// NilChance sets the probability of creating a nil pointer, map, or slice to
+// 'p'. 'p' should be between 0 (no nils) and 1 (all nils), inclusive.
+func (f *Fuzzer) NilChance(p float64) *Fuzzer {
+	if p < 0 || p > 1 {
+		panic("p should be between 0 and 1, inclusive.")
+	}
+	f.nilChance = p
+	return f
+}
+
+// NumElements sets the minimum and maximum number of elements that will be
+// added to a non-nil map or slice.
+func (f *Fuzzer) NumElements(atLeast, atMost int) *Fuzzer {
+	if atLeast > atMost {
+		panic("atLeast must be <= atMost")
+	}
+	if atLeast < 0 {
+		panic("atLeast must be >= 0")
+	}
+	f.minElements = atLeast
+	f.maxElements = atMost
+	return f
+}
+
+func (f *Fuzzer) genElementCount() int {
+	if f.minElements == f.maxElements {
+		return f.minElements
+	}
+	return f.minElements + f.r.Intn(f.maxElements-f.minElements+1)
+}
+
+func (f *Fuzzer) genShouldFill() bool {
+	return f.r.Float64() > f.nilChance
+}
+
+// Fuzz recursively fills all of obj's fields with something random.  First
+// this tries to find a custom fuzz function (see Funcs).  If there is no
+// custom function this tests whether the object implements fuzz.Interface and,
+// if so, calls Fuzz on it to fuzz itself.  If that fails, this will see if
+// there is a default fuzz function provided by this package.  If all of that
+// fails, this will generate random values for all primitive fields and then
+// recurse for all non-primitives.
+//
+// Not safe for cyclic or tree-like structs!
+//
+// obj must be a pointer. Only exported (public) fields can be set (thanks, golang :/ )
+// Intended for tests, so will panic on bad input or unimplemented fields.
+func (f *Fuzzer) Fuzz(obj interface{}) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("needed ptr!")
+	}
+	v = v.Elem()
+	f.doFuzz(v, 0)
+}
+
+// FuzzNoCustom is just like Fuzz, except that any custom fuzz function for
+// obj's type will not be called and obj will not be tested for fuzz.Interface
+// conformance.  This applies only to obj and not other instances of obj's
+// type.
+// Not safe for cyclic or tree-like structs!
+// obj must be a pointer. Only exported (public) fields can be set (thanks, golang :/ )
+// Intended for tests, so will panic on bad input or unimplemented fields.
+func (f *Fuzzer) FuzzNoCustom(obj interface{}) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("needed ptr!")
+	}
+	v = v.Elem()
+	f.doFuzz(v, flagNoCustomFuzz)
+}
+
+const (
+	// Do not try to find a custom fuzz function.  Does not apply recursively.
+	flagNoCustomFuzz uint64 = 1 << iota
+)
+
+func (f *Fuzzer) doFuzz(v reflect.Value, flags uint64) {
+	if !v.CanSet() {
+		return
+	}
+
+	if flags&flagNoCustomFuzz == 0 {
+		// Check for both pointer and non-pointer custom functions.
+		if v.CanAddr() && f.tryCustom(v.Addr()) {
+			return
+		}
+		if f.tryCustom(v) {
+			return
+		}
+	}
+
+	if fn, ok := fillFuncMap[v.Kind()]; ok {
+		fn(v, f.r)
+		return
+	}
+	switch v.Kind() {
+	case reflect.Map:
+		if f.genShouldFill() {
+			v.Set(reflect.MakeMap(v.Type()))
+			n := f.genElementCount()
+			for i := 0; i < n; i++ {
+				key := reflect.New(v.Type().Key()).Elem()
+				f.doFuzz(key, 0)
+				val := reflect.New(v.Type().Elem()).Elem()
+				f.doFuzz(val, 0)
+				v.SetMapIndex(key, val)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Ptr:
+		if f.genShouldFill() {
+			v.Set(reflect.New(v.Type().Elem()))
+			f.doFuzz(v.Elem(), 0)
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Slice:
+		if f.genShouldFill() {
+			n := f.genElementCount()
+			v.Set(reflect.MakeSlice(v.Type(), n, n))
+			for i := 0; i < n; i++ {
+				f.doFuzz(v.Index(i), 0)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Array:
+		if f.genShouldFill() {
+			n := v.Len()
+			for i := 0; i < n; i++ {
+				f.doFuzz(v.Index(i), 0)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			f.doFuzz(v.Field(i), 0)
+		}
+	case reflect.Chan:
+		fallthrough
+	case reflect.Func:
+		fallthrough
+	case reflect.Interface:
+		fallthrough
+	default:
+		panic(fmt.Sprintf("Can't handle %#v", v.Interface()))
+	}
+}
+
+// tryCustom searches for custom handlers, and returns true iff it finds a match
+// and successfully randomizes v.
+func (f *Fuzzer) tryCustom(v reflect.Value) bool {
+	// First: see if we have a fuzz function for it.
+	doCustom, ok := f.fuzzFuncs[v.Type()]
+	if !ok {
+		// Second: see if it can fuzz itself.
+		if v.CanInterface() {
+			intf := v.Interface()
+			if fuzzable, ok := intf.(Interface); ok {
+				fuzzable.Fuzz(Continue{f: f, Rand: f.r})
+				return true
+			}
+		}
+		// Finally: see if there is a default fuzz function.
+		doCustom, ok = f.defaultFuzzFuncs[v.Type()]
+		if !ok {
+			return false
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			if !v.CanSet() {
+				return false
+			}
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+	case reflect.Map:
+		if v.IsNil() {
+			if !v.CanSet() {
+				return false
+			}
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+	default:
+		return false
+	}
+
+	doCustom.Call([]reflect.Value{v, reflect.ValueOf(Continue{
+		f:    f,
+		Rand: f.r,
+	})})
+	return true
+}
+
+// Interface represents an object that knows how to fuzz itself.  Any time we
+// find a type that implements this interface we will delegate the act of
+// fuzzing itself.
+type Interface interface {
+	Fuzz(c Continue)
+}
+
+// Continue can be passed to custom fuzzing functions to allow them to use
+// the correct source of randomness and to continue fuzzing their members.
+type Continue struct {
+	f *Fuzzer
+
+	// For convenience, Continue implements rand.Rand via embedding.
+	// Use this for generating any randomness if you want your fuzzing
+	// to be repeatable for a given seed.
+	*rand.Rand
+}
+
+// Fuzz continues fuzzing obj. obj must be a pointer.
+func (c Continue) Fuzz(obj interface{}) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("needed ptr!")
+	}
+	v = v.Elem()
+	c.f.doFuzz(v, 0)
+}
+
+// FuzzNoCustom continues fuzzing obj, except that any custom fuzz function for
+// obj's type will not be called and obj will not be tested for fuzz.Interface
+// conformance.  This applies only to obj and not other instances of obj's
+// type.
+func (c Continue) FuzzNoCustom(obj interface{}) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("needed ptr!")
+	}
+	v = v.Elem()
+	c.f.doFuzz(v, flagNoCustomFuzz)
+}
+
+// RandString makes a random string up to 20 characters long. The returned string
+// may include a variety of (valid) UTF-8 encodings.
+func (c Continue) RandString() string {
+	return randString(c.Rand)
+}
+
+// RandUint64 makes random 64 bit numbers.
+// Weirdly, rand doesn't have a function that gives you 64 random bits.
+func (c Continue) RandUint64() uint64 {
+	return randUint64(c.Rand)
+}
+
+// RandBool returns true or false randomly.
+func (c Continue) RandBool() bool {
+	return randBool(c.Rand)
+}
+
+func fuzzInt(v reflect.Value, r *rand.Rand) {
+	v.SetInt(int64(randUint64(r)))
+}
+
+func fuzzUint(v reflect.Value, r *rand.Rand) {
+	v.SetUint(randUint64(r))
+}
+
+func fuzzTime(t *time.Time, c Continue) {
+	var sec, nsec int64
+	// Allow for about 1000 years of random time values, which keeps things
+	// like JSON parsing reasonably happy.
+	sec = c.Rand.Int63n(1000 * 365 * 24 * 60 * 60)
+	c.Fuzz(&nsec)
+	*t = time.Unix(sec, nsec)
+}
+
+var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
+	reflect.Bool: func(v reflect.Value, r *rand.Rand) {
+		v.SetBool(randBool(r))
+	},
+	reflect.Int:     fuzzInt,
+	reflect.Int8:    fuzzInt,
+	reflect.Int16:   fuzzInt,
+	reflect.Int32:   fuzzInt,
+	reflect.Int64:   fuzzInt,
+	reflect.Uint:    fuzzUint,
+	reflect.Uint8:   fuzzUint,
+	reflect.Uint16:  fuzzUint,
+	reflect.Uint32:  fuzzUint,
+	reflect.Uint64:  fuzzUint,
+	reflect.Uintptr: fuzzUint,
+	reflect.Float32: func(v reflect.Value, r *rand.Rand) {
+		v.SetFloat(float64(r.Float32()))
+	},
+	reflect.Float64: func(v reflect.Value, r *rand.Rand) {
+		v.SetFloat(r.Float64())
+	},
+	reflect.Complex64: func(v reflect.Value, r *rand.Rand) {
+		panic("unimplemented")
+	},
+	reflect.Complex128: func(v reflect.Value, r *rand.Rand) {
+		panic("unimplemented")
+	},
+	reflect.String: func(v reflect.Value, r *rand.Rand) {
+		v.SetString(randString(r))
+	},
+	reflect.UnsafePointer: func(v reflect.Value, r *rand.Rand) {
+		panic("unimplemented")
+	},
+}
+
+// randBool returns true or false randomly.
+func randBool(r *rand.Rand) bool {
+	if r.Int()&1 == 1 {
+		return true
+	}
+	return false
+}
+
+type charRange struct {
+	first, last rune
+}
+
+// choose returns a random unicode character from the given range, using the
+// given randomness source.
+func (r *charRange) choose(rand *rand.Rand) rune {
+	count := int64(r.last - r.first)
+	return r.first + rune(rand.Int63n(count))
+}
+
+var unicodeRanges = []charRange{
+	{' ', '~'},           // ASCII characters
+	{'\u00a0', '\u02af'}, // Multi-byte encoded characters
+	{'\u4e00', '\u9fff'}, // Common CJK (even longer encodings)
+}
+
+// randString makes a random string up to 20 characters long. The returned string
+// may include a variety of (valid) UTF-8 encodings.
+func randString(r *rand.Rand) string {
+	n := r.Intn(20)
+	runes := make([]rune, n)
+	for i := range runes {
+		runes[i] = unicodeRanges[r.Intn(len(unicodeRanges))].choose(r)
+	}
+	return string(runes)
+}
+
+// randUint64 makes random 64 bit numbers.
+// Weirdly, rand doesn't have a function that gives you 64 random bits.
+func randUint64(r *rand.Rand) uint64 {
+	return uint64(r.Uint32())<<32 | uint64(r.Uint32())
+}

--- a/deps/github.com/google/gofuzz/fuzz_test.go
+++ b/deps/github.com/google/gofuzz/fuzz_test.go
@@ -1,0 +1,428 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzz
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestFuzz_basic(t *testing.T) {
+	obj := &struct {
+		I    int
+		I8   int8
+		I16  int16
+		I32  int32
+		I64  int64
+		U    uint
+		U8   uint8
+		U16  uint16
+		U32  uint32
+		U64  uint64
+		Uptr uintptr
+		S    string
+		B    bool
+		T    time.Time
+	}{}
+
+	failed := map[string]int{}
+	for i := 0; i < 10; i++ {
+		New().Fuzz(obj)
+
+		if n, v := "i", obj.I; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "i8", obj.I8; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "i16", obj.I16; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "i32", obj.I32; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "i64", obj.I64; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "u", obj.U; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "u8", obj.U8; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "u16", obj.U16; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "u32", obj.U32; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "u64", obj.U64; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "uptr", obj.Uptr; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "s", obj.S; v == "" {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "b", obj.B; v == false {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "t", obj.T; v.IsZero() {
+			failed[n] = failed[n] + 1
+		}
+	}
+	checkFailed(t, failed)
+}
+
+func checkFailed(t *testing.T, failed map[string]int) {
+	for k, v := range failed {
+		if v > 8 {
+			t.Errorf("%v seems to not be getting set, was zero value %v times", k, v)
+		}
+	}
+}
+
+func TestFuzz_structptr(t *testing.T) {
+	obj := &struct {
+		A *struct {
+			S string
+		}
+	}{}
+
+	f := New().NilChance(.5)
+	failed := map[string]int{}
+	for i := 0; i < 10; i++ {
+		f.Fuzz(obj)
+
+		if n, v := "a not nil", obj.A; v == nil {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "a nil", obj.A; v != nil {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "as", obj.A; v == nil || v.S == "" {
+			failed[n] = failed[n] + 1
+		}
+	}
+	checkFailed(t, failed)
+}
+
+// tryFuzz tries fuzzing up to 20 times. Fail if check() never passes, report the highest
+// stage it ever got to.
+func tryFuzz(t *testing.T, f *Fuzzer, obj interface{}, check func() (stage int, passed bool)) {
+	maxStage := 0
+	for i := 0; i < 20; i++ {
+		f.Fuzz(obj)
+		stage, passed := check()
+		if stage > maxStage {
+			maxStage = stage
+		}
+		if passed {
+			return
+		}
+	}
+	t.Errorf("Only ever got to stage %v", maxStage)
+}
+
+func TestFuzz_structmap(t *testing.T) {
+	obj := &struct {
+		A map[struct {
+			S string
+		}]struct {
+			S2 string
+		}
+		B map[string]string
+	}{}
+
+	tryFuzz(t, New(), obj, func() (int, bool) {
+		if obj.A == nil {
+			return 1, false
+		}
+		if len(obj.A) == 0 {
+			return 2, false
+		}
+		for k, v := range obj.A {
+			if k.S == "" {
+				return 3, false
+			}
+			if v.S2 == "" {
+				return 4, false
+			}
+		}
+
+		if obj.B == nil {
+			return 5, false
+		}
+		if len(obj.B) == 0 {
+			return 6, false
+		}
+		for k, v := range obj.B {
+			if k == "" {
+				return 7, false
+			}
+			if v == "" {
+				return 8, false
+			}
+		}
+		return 9, true
+	})
+}
+
+func TestFuzz_structslice(t *testing.T) {
+	obj := &struct {
+		A []struct {
+			S string
+		}
+		B []string
+	}{}
+
+	tryFuzz(t, New(), obj, func() (int, bool) {
+		if obj.A == nil {
+			return 1, false
+		}
+		if len(obj.A) == 0 {
+			return 2, false
+		}
+		for _, v := range obj.A {
+			if v.S == "" {
+				return 3, false
+			}
+		}
+
+		if obj.B == nil {
+			return 4, false
+		}
+		if len(obj.B) == 0 {
+			return 5, false
+		}
+		for _, v := range obj.B {
+			if v == "" {
+				return 6, false
+			}
+		}
+		return 7, true
+	})
+}
+
+func TestFuzz_structarray(t *testing.T) {
+	obj := &struct {
+		A [3]struct {
+			S string
+		}
+		B [2]int
+	}{}
+
+	tryFuzz(t, New(), obj, func() (int, bool) {
+		for _, v := range obj.A {
+			if v.S == "" {
+				return 1, false
+			}
+		}
+
+		for _, v := range obj.B {
+			if v == 0 {
+				return 2, false
+			}
+		}
+		return 3, true
+	})
+}
+
+func TestFuzz_custom(t *testing.T) {
+	obj := &struct {
+		A string
+		B *string
+		C map[string]string
+		D *map[string]string
+	}{}
+
+	testPhrase := "gotcalled"
+	testMap := map[string]string{"C": "D"}
+	f := New().Funcs(
+		func(s *string, c Continue) {
+			*s = testPhrase
+		},
+		func(m map[string]string, c Continue) {
+			m["C"] = "D"
+		},
+	)
+
+	tryFuzz(t, f, obj, func() (int, bool) {
+		if obj.A != testPhrase {
+			return 1, false
+		}
+		if obj.B == nil {
+			return 2, false
+		}
+		if *obj.B != testPhrase {
+			return 3, false
+		}
+		if e, a := testMap, obj.C; !reflect.DeepEqual(e, a) {
+			return 4, false
+		}
+		if obj.D == nil {
+			return 5, false
+		}
+		if e, a := testMap, *obj.D; !reflect.DeepEqual(e, a) {
+			return 6, false
+		}
+		return 7, true
+	})
+}
+
+type SelfFuzzer string
+
+// Implement fuzz.Interface.
+func (sf *SelfFuzzer) Fuzz(c Continue) {
+	*sf = selfFuzzerTestPhrase
+}
+
+const selfFuzzerTestPhrase = "was fuzzed"
+
+func TestFuzz_interface(t *testing.T) {
+	f := New()
+
+	var obj1 SelfFuzzer
+	tryFuzz(t, f, &obj1, func() (int, bool) {
+		if obj1 != selfFuzzerTestPhrase {
+			return 1, false
+		}
+		return 1, true
+	})
+
+	var obj2 map[int]SelfFuzzer
+	tryFuzz(t, f, &obj2, func() (int, bool) {
+		for _, v := range obj2 {
+			if v != selfFuzzerTestPhrase {
+				return 1, false
+			}
+		}
+		return 1, true
+	})
+}
+
+func TestFuzz_interfaceAndFunc(t *testing.T) {
+	const privateTestPhrase = "private phrase"
+	f := New().Funcs(
+		// This should take precedence over SelfFuzzer.Fuzz().
+		func(s *SelfFuzzer, c Continue) {
+			*s = privateTestPhrase
+		},
+	)
+
+	var obj1 SelfFuzzer
+	tryFuzz(t, f, &obj1, func() (int, bool) {
+		if obj1 != privateTestPhrase {
+			return 1, false
+		}
+		return 1, true
+	})
+
+	var obj2 map[int]SelfFuzzer
+	tryFuzz(t, f, &obj2, func() (int, bool) {
+		for _, v := range obj2 {
+			if v != privateTestPhrase {
+				return 1, false
+			}
+		}
+		return 1, true
+	})
+}
+
+func TestFuzz_noCustom(t *testing.T) {
+	type Inner struct {
+		Str string
+	}
+	type Outer struct {
+		Str string
+		In  Inner
+	}
+
+	testPhrase := "gotcalled"
+	f := New().Funcs(
+		func(outer *Outer, c Continue) {
+			outer.Str = testPhrase
+			c.Fuzz(&outer.In)
+		},
+		func(inner *Inner, c Continue) {
+			inner.Str = testPhrase
+		},
+	)
+	c := Continue{f: f, Rand: f.r}
+
+	// Fuzzer.Fuzz()
+	obj1 := Outer{}
+	f.Fuzz(&obj1)
+	if obj1.Str != testPhrase {
+		t.Errorf("expected Outer custom function to have been called")
+	}
+	if obj1.In.Str != testPhrase {
+		t.Errorf("expected Inner custom function to have been called")
+	}
+
+	// Continue.Fuzz()
+	obj2 := Outer{}
+	c.Fuzz(&obj2)
+	if obj2.Str != testPhrase {
+		t.Errorf("expected Outer custom function to have been called")
+	}
+	if obj2.In.Str != testPhrase {
+		t.Errorf("expected Inner custom function to have been called")
+	}
+
+	// Fuzzer.FuzzNoCustom()
+	obj3 := Outer{}
+	f.FuzzNoCustom(&obj3)
+	if obj3.Str == testPhrase {
+		t.Errorf("expected Outer custom function to not have been called")
+	}
+	if obj3.In.Str != testPhrase {
+		t.Errorf("expected Inner custom function to have been called")
+	}
+
+	// Continue.FuzzNoCustom()
+	obj4 := Outer{}
+	c.FuzzNoCustom(&obj4)
+	if obj4.Str == testPhrase {
+		t.Errorf("expected Outer custom function to not have been called")
+	}
+	if obj4.In.Str != testPhrase {
+		t.Errorf("expected Inner custom function to have been called")
+	}
+}
+
+func TestFuzz_NumElements(t *testing.T) {
+	f := New().NilChance(0).NumElements(0, 1)
+	obj := &struct {
+		A []int
+	}{}
+
+	tryFuzz(t, f, obj, func() (int, bool) {
+		if obj.A == nil {
+			return 1, false
+		}
+		return 2, len(obj.A) == 0
+	})
+	tryFuzz(t, f, obj, func() (int, bool) {
+		if obj.A == nil {
+			return 3, false
+		}
+		return 4, len(obj.A) == 1
+	})
+}

--- a/deps/github.com/pkg/errors/.gitignore
+++ b/deps/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/deps/github.com/pkg/errors/.travis.yml
+++ b/deps/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.3
+  - 1.7.3
+  - tip
+
+script:
+  - go test -v ./...

--- a/deps/github.com/pkg/errors/LICENSE
+++ b/deps/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/deps/github.com/pkg/errors/README.md
+++ b/deps/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/deps/github.com/pkg/errors/appveyor.yml
+++ b/deps/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/deps/github.com/pkg/errors/bench_test.go
+++ b/deps/github.com/pkg/errors/bench_test.go
@@ -1,0 +1,60 @@
+// +build go1.7
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	stderrors "errors"
+)
+
+func noErrors(at, depth int) error {
+	if at >= depth {
+		return stderrors.New("no error")
+	}
+	return noErrors(at+1, depth)
+}
+
+func yesErrors(at, depth int) error {
+	if at >= depth {
+		return New("ye error")
+	}
+	return yesErrors(at+1, depth)
+}
+
+func BenchmarkErrors(b *testing.B) {
+	var toperr error
+	type run struct {
+		stack int
+		std   bool
+	}
+	runs := []run{
+		{10, false},
+		{10, true},
+		{100, false},
+		{100, true},
+		{1000, false},
+		{1000, true},
+	}
+	for _, r := range runs {
+		part := "pkg/errors"
+		if r.std {
+			part = "errors"
+		}
+		name := fmt.Sprintf("%s-stack-%d", part, r.stack)
+		b.Run(name, func(b *testing.B) {
+			var err error
+			f := yesErrors
+			if r.std {
+				f = noErrors
+			}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				err = f(0, r.stack)
+			}
+			b.StopTimer()
+			toperr = err
+		})
+	}
+}

--- a/deps/github.com/pkg/errors/errors.go
+++ b/deps/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/deps/github.com/pkg/errors/errors_test.go
+++ b/deps/github.com/pkg/errors/errors_test.go
@@ -1,0 +1,225 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		err  string
+		want error
+	}{
+		{"", fmt.Errorf("")},
+		{"foo", fmt.Errorf("foo")},
+		{"foo", New("foo")},
+		{"string with format specifiers: %v", errors.New("string with format specifiers: %v")},
+	}
+
+	for _, tt := range tests {
+		got := New(tt.err)
+		if got.Error() != tt.want.Error() {
+			t.Errorf("New.Error(): got: %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestWrapNil(t *testing.T) {
+	got := Wrap(nil, "no error")
+	if got != nil {
+		t.Errorf("Wrap(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWrap(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{Wrap(io.EOF, "read error"), "client error", "client error: read error: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := Wrap(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("Wrap(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+type nilError struct{}
+
+func (nilError) Error() string { return "nil error" }
+
+func TestCause(t *testing.T) {
+	x := New("error")
+	tests := []struct {
+		err  error
+		want error
+	}{{
+		// nil error is nil
+		err:  nil,
+		want: nil,
+	}, {
+		// explicit nil error is nil
+		err:  (error)(nil),
+		want: nil,
+	}, {
+		// typed nil is nil
+		err:  (*nilError)(nil),
+		want: (*nilError)(nil),
+	}, {
+		// uncaused error is unaffected
+		err:  io.EOF,
+		want: io.EOF,
+	}, {
+		// caused error returns cause
+		err:  Wrap(io.EOF, "ignored"),
+		want: io.EOF,
+	}, {
+		err:  x, // return from errors.New
+		want: x,
+	}, {
+		WithMessage(nil, "whoops"),
+		nil,
+	}, {
+		WithMessage(io.EOF, "whoops"),
+		io.EOF,
+	}, {
+		WithStack(nil),
+		nil,
+	}, {
+		WithStack(io.EOF),
+		io.EOF,
+	}}
+
+	for i, tt := range tests {
+		got := Cause(tt.err)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
+		}
+	}
+}
+
+func TestWrapfNil(t *testing.T) {
+	got := Wrapf(nil, "no error")
+	if got != nil {
+		t.Errorf("Wrapf(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWrapf(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{Wrapf(io.EOF, "read error without format specifiers"), "client error", "client error: read error without format specifiers: EOF"},
+		{Wrapf(io.EOF, "read error with %d format specifier", 1), "client error", "client error: read error with 1 format specifier: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := Wrapf(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("Wrapf(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{Errorf("read error without format specifiers"), "read error without format specifiers"},
+		{Errorf("read error with %d format specifier", 1), "read error with 1 format specifier"},
+	}
+
+	for _, tt := range tests {
+		got := tt.err.Error()
+		if got != tt.want {
+			t.Errorf("Errorf(%v): got: %q, want %q", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestWithStackNil(t *testing.T) {
+	got := WithStack(nil)
+	if got != nil {
+		t.Errorf("WithStack(nil): got %#v, expected nil", got)
+	}
+}
+
+func TestWithStack(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{io.EOF, "EOF"},
+		{WithStack(io.EOF), "EOF"},
+	}
+
+	for _, tt := range tests {
+		got := WithStack(tt.err).Error()
+		if got != tt.want {
+			t.Errorf("WithStack(%v): got: %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestWithMessageNil(t *testing.T) {
+	got := WithMessage(nil, "no error")
+	if got != nil {
+		t.Errorf("WithMessage(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWithMessage(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{WithMessage(io.EOF, "read error"), "client error", "client error: read error: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := WithMessage(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("WithMessage(%v, %q): got: %q, want %q", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+// errors.New, etc values are not expected to be compared by value
+// but the change in errors#27 made them incomparable. Assert that
+// various kinds of errors have a functional equality operator, even
+// if the result of that equality is always false.
+func TestErrorEquality(t *testing.T) {
+	vals := []error{
+		nil,
+		io.EOF,
+		errors.New("EOF"),
+		New("EOF"),
+		Errorf("EOF"),
+		Wrap(io.EOF, "EOF"),
+		Wrapf(io.EOF, "EOF%d", 2),
+		WithMessage(nil, "whoops"),
+		WithMessage(io.EOF, "whoops"),
+		WithStack(io.EOF),
+		WithStack(nil),
+	}
+
+	for i := range vals {
+		for j := range vals {
+			_ = vals[i] == vals[j] // mustn't panic
+		}
+	}
+}

--- a/deps/github.com/pkg/errors/example_test.go
+++ b/deps/github.com/pkg/errors/example_test.go
@@ -1,0 +1,205 @@
+package errors_test
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+func ExampleNew() {
+	err := errors.New("whoops")
+	fmt.Println(err)
+
+	// Output: whoops
+}
+
+func ExampleNew_printf() {
+	err := errors.New("whoops")
+	fmt.Printf("%+v", err)
+
+	// Example output:
+	// whoops
+	// github.com/pkg/errors_test.ExampleNew_printf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:17
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+}
+
+func ExampleWithMessage() {
+	cause := errors.New("whoops")
+	err := errors.WithMessage(cause, "oh noes")
+	fmt.Println(err)
+
+	// Output: oh noes: whoops
+}
+
+func ExampleWithStack() {
+	cause := errors.New("whoops")
+	err := errors.WithStack(cause)
+	fmt.Println(err)
+
+	// Output: whoops
+}
+
+func ExampleWithStack_printf() {
+	cause := errors.New("whoops")
+	err := errors.WithStack(cause)
+	fmt.Printf("%+v", err)
+
+	// Example Output:
+	// whoops
+	// github.com/pkg/errors_test.ExampleWithStack_printf
+	//         /home/fabstu/go/src/github.com/pkg/errors/example_test.go:55
+	// testing.runExample
+	//         /usr/lib/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /usr/lib/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /usr/lib/go/src/testing/testing.go:744
+	// main.main
+	//         github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /usr/lib/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /usr/lib/go/src/runtime/asm_amd64.s:2086
+	// github.com/pkg/errors_test.ExampleWithStack_printf
+	//         /home/fabstu/go/src/github.com/pkg/errors/example_test.go:56
+	// testing.runExample
+	//         /usr/lib/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /usr/lib/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /usr/lib/go/src/testing/testing.go:744
+	// main.main
+	//         github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /usr/lib/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /usr/lib/go/src/runtime/asm_amd64.s:2086
+}
+
+func ExampleWrap() {
+	cause := errors.New("whoops")
+	err := errors.Wrap(cause, "oh noes")
+	fmt.Println(err)
+
+	// Output: oh noes: whoops
+}
+
+func fn() error {
+	e1 := errors.New("error")
+	e2 := errors.Wrap(e1, "inner")
+	e3 := errors.Wrap(e2, "middle")
+	return errors.Wrap(e3, "outer")
+}
+
+func ExampleCause() {
+	err := fn()
+	fmt.Println(err)
+	fmt.Println(errors.Cause(err))
+
+	// Output: outer: middle: inner: error
+	// error
+}
+
+func ExampleWrap_extended() {
+	err := fn()
+	fmt.Printf("%+v\n", err)
+
+	// Example output:
+	// error
+	// github.com/pkg/errors_test.fn
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:47
+	// github.com/pkg/errors_test.ExampleCause_printf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:63
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:104
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+	// github.com/pkg/errors_test.fn
+	// 	  /home/dfc/src/github.com/pkg/errors/example_test.go:48: inner
+	// github.com/pkg/errors_test.fn
+	//        /home/dfc/src/github.com/pkg/errors/example_test.go:49: middle
+	// github.com/pkg/errors_test.fn
+	//      /home/dfc/src/github.com/pkg/errors/example_test.go:50: outer
+}
+
+func ExampleWrapf() {
+	cause := errors.New("whoops")
+	err := errors.Wrapf(cause, "oh noes #%d", 2)
+	fmt.Println(err)
+
+	// Output: oh noes #2: whoops
+}
+
+func ExampleErrorf_extended() {
+	err := errors.Errorf("whoops: %s", "foo")
+	fmt.Printf("%+v", err)
+
+	// Example output:
+	// whoops: foo
+	// github.com/pkg/errors_test.ExampleErrorf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:101
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:102
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+}
+
+func Example_stackTrace() {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+
+	err, ok := errors.Cause(fn()).(stackTracer)
+	if !ok {
+		panic("oops, err does not implement stackTracer")
+	}
+
+	st := err.StackTrace()
+	fmt.Printf("%+v", st[0:2]) // top two frames
+
+	// Example output:
+	// github.com/pkg/errors_test.fn
+	//	/home/dfc/src/github.com/pkg/errors/example_test.go:47
+	// github.com/pkg/errors_test.Example_stackTrace
+	//	/home/dfc/src/github.com/pkg/errors/example_test.go:127
+}
+
+func ExampleCause_printf() {
+	err := errors.Wrap(func() error {
+		return func() error {
+			return errors.Errorf("hello %s", fmt.Sprintf("world"))
+		}()
+	}(), "failed")
+
+	fmt.Printf("%v", err)
+
+	// Output: failed: hello world
+}

--- a/deps/github.com/pkg/errors/format_test.go
+++ b/deps/github.com/pkg/errors/format_test.go
@@ -1,0 +1,535 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestFormatNew(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		New("error"),
+		"%s",
+		"error",
+	}, {
+		New("error"),
+		"%v",
+		"error",
+	}, {
+		New("error"),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatNew\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:26",
+	}, {
+		New("error"),
+		"%q",
+		`"error"`,
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatErrorf(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Errorf("%s", "error"),
+		"%s",
+		"error",
+	}, {
+		Errorf("%s", "error"),
+		"%v",
+		"error",
+	}, {
+		Errorf("%s", "error"),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatErrorf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:56",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWrap(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Wrap(New("error"), "error2"),
+		"%s",
+		"error2: error",
+	}, {
+		Wrap(New("error"), "error2"),
+		"%v",
+		"error2: error",
+	}, {
+		Wrap(New("error"), "error2"),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:82",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%s",
+		"error: EOF",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%v",
+		"error: EOF",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%+v",
+		"EOF\n" +
+			"error\n" +
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:96",
+	}, {
+		Wrap(Wrap(io.EOF, "error1"), "error2"),
+		"%+v",
+		"EOF\n" +
+			"error1\n" +
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:103\n",
+	}, {
+		Wrap(New("error with space"), "context"),
+		"%q",
+		`"context: error with space"`,
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWrapf(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Wrapf(io.EOF, "error%d", 2),
+		"%s",
+		"error2: EOF",
+	}, {
+		Wrapf(io.EOF, "error%d", 2),
+		"%v",
+		"error2: EOF",
+	}, {
+		Wrapf(io.EOF, "error%d", 2),
+		"%+v",
+		"EOF\n" +
+			"error2\n" +
+			"github.com/pkg/errors.TestFormatWrapf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:134",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%s",
+		"error2: error",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%v",
+		"error2: error",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatWrapf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:149",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWithStack(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   []string
+	}{{
+		WithStack(io.EOF),
+		"%s",
+		[]string{"EOF"},
+	}, {
+		WithStack(io.EOF),
+		"%v",
+		[]string{"EOF"},
+	}, {
+		WithStack(io.EOF),
+		"%+v",
+		[]string{"EOF",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:175"},
+	}, {
+		WithStack(New("error")),
+		"%s",
+		[]string{"error"},
+	}, {
+		WithStack(New("error")),
+		"%v",
+		[]string{"error"},
+	}, {
+		WithStack(New("error")),
+		"%+v",
+		[]string{"error",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:189",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:189"},
+	}, {
+		WithStack(WithStack(io.EOF)),
+		"%+v",
+		[]string{"EOF",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:197",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:197"},
+	}, {
+		WithStack(WithStack(Wrapf(io.EOF, "message"))),
+		"%+v",
+		[]string{"EOF",
+			"message",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205"},
+	}, {
+		WithStack(Errorf("error%d", 1)),
+		"%+v",
+		[]string{"error1",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:216",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:216"},
+	}}
+
+	for i, tt := range tests {
+		testFormatCompleteCompare(t, i, tt.error, tt.format, tt.want, true)
+	}
+}
+
+func TestFormatWithMessage(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   []string
+	}{{
+		WithMessage(New("error"), "error2"),
+		"%s",
+		[]string{"error2: error"},
+	}, {
+		WithMessage(New("error"), "error2"),
+		"%v",
+		[]string{"error2: error"},
+	}, {
+		WithMessage(New("error"), "error2"),
+		"%+v",
+		[]string{
+			"error",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:244",
+			"error2"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%s",
+		[]string{"addition1: EOF"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%v",
+		[]string{"addition1: EOF"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%+v",
+		[]string{"EOF", "addition1"},
+	}, {
+		WithMessage(WithMessage(io.EOF, "addition1"), "addition2"),
+		"%v",
+		[]string{"addition2: addition1: EOF"},
+	}, {
+		WithMessage(WithMessage(io.EOF, "addition1"), "addition2"),
+		"%+v",
+		[]string{"EOF", "addition1", "addition2"},
+	}, {
+		Wrap(WithMessage(io.EOF, "error1"), "error2"),
+		"%+v",
+		[]string{"EOF", "error1", "error2",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:272"},
+	}, {
+		WithMessage(Errorf("error%d", 1), "error2"),
+		"%+v",
+		[]string{"error1",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:278",
+			"error2"},
+	}, {
+		WithMessage(WithStack(io.EOF), "error"),
+		"%+v",
+		[]string{
+			"EOF",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:285",
+			"error"},
+	}, {
+		WithMessage(Wrap(WithStack(io.EOF), "inside-error"), "outside-error"),
+		"%+v",
+		[]string{
+			"EOF",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:293",
+			"inside-error",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:293",
+			"outside-error"},
+	}}
+
+	for i, tt := range tests {
+		testFormatCompleteCompare(t, i, tt.error, tt.format, tt.want, true)
+	}
+}
+
+func TestFormatGeneric(t *testing.T) {
+	starts := []struct {
+		err  error
+		want []string
+	}{
+		{New("new-error"), []string{
+			"new-error",
+			"github.com/pkg/errors.TestFormatGeneric\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:315"},
+		}, {Errorf("errorf-error"), []string{
+			"errorf-error",
+			"github.com/pkg/errors.TestFormatGeneric\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:319"},
+		}, {errors.New("errors-new-error"), []string{
+			"errors-new-error"},
+		},
+	}
+
+	wrappers := []wrapper{
+		{
+			func(err error) error { return WithMessage(err, "with-message") },
+			[]string{"with-message"},
+		}, {
+			func(err error) error { return WithStack(err) },
+			[]string{
+				"github.com/pkg/errors.(func·002|TestFormatGeneric.func2)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:333",
+			},
+		}, {
+			func(err error) error { return Wrap(err, "wrap-error") },
+			[]string{
+				"wrap-error",
+				"github.com/pkg/errors.(func·003|TestFormatGeneric.func3)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:339",
+			},
+		}, {
+			func(err error) error { return Wrapf(err, "wrapf-error%d", 1) },
+			[]string{
+				"wrapf-error1",
+				"github.com/pkg/errors.(func·004|TestFormatGeneric.func4)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:346",
+			},
+		},
+	}
+
+	for s := range starts {
+		err := starts[s].err
+		want := starts[s].want
+		testFormatCompleteCompare(t, s, err, "%+v", want, false)
+		testGenericRecursive(t, err, want, wrappers, 3)
+	}
+}
+
+func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string) {
+	got := fmt.Sprintf(format, arg)
+	gotLines := strings.SplitN(got, "\n", -1)
+	wantLines := strings.SplitN(want, "\n", -1)
+
+	if len(wantLines) > len(gotLines) {
+		t.Errorf("test %d: wantLines(%d) > gotLines(%d):\n got: %q\nwant: %q", n+1, len(wantLines), len(gotLines), got, want)
+		return
+	}
+
+	for i, w := range wantLines {
+		match, err := regexp.MatchString(w, gotLines[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("test %d: line %d: fmt.Sprintf(%q, err):\n got: %q\nwant: %q", n+1, i+1, format, got, want)
+		}
+	}
+}
+
+var stackLineR = regexp.MustCompile(`\.`)
+
+// parseBlocks parses input into a slice, where:
+//  - incase entry contains a newline, its a stacktrace
+//  - incase entry contains no newline, its a solo line.
+//
+// Detecting stack boundaries only works incase the WithStack-calls are
+// to be found on the same line, thats why it is optionally here.
+//
+// Example use:
+//
+// for _, e := range blocks {
+//   if strings.ContainsAny(e, "\n") {
+//     // Match as stack
+//   } else {
+//     // Match as line
+//   }
+// }
+//
+func parseBlocks(input string, detectStackboundaries bool) ([]string, error) {
+	var blocks []string
+
+	stack := ""
+	wasStack := false
+	lines := map[string]bool{} // already found lines
+
+	for _, l := range strings.Split(input, "\n") {
+		isStackLine := stackLineR.MatchString(l)
+
+		switch {
+		case !isStackLine && wasStack:
+			blocks = append(blocks, stack, l)
+			stack = ""
+			lines = map[string]bool{}
+		case isStackLine:
+			if wasStack {
+				// Detecting two stacks after another, possible cause lines match in
+				// our tests due to WithStack(WithStack(io.EOF)) on same line.
+				if detectStackboundaries {
+					if lines[l] {
+						if len(stack) == 0 {
+							return nil, errors.New("len of block must not be zero here")
+						}
+
+						blocks = append(blocks, stack)
+						stack = l
+						lines = map[string]bool{l: true}
+						continue
+					}
+				}
+
+				stack = stack + "\n" + l
+			} else {
+				stack = l
+			}
+			lines[l] = true
+		case !isStackLine && !wasStack:
+			blocks = append(blocks, l)
+		default:
+			return nil, errors.New("must not happen")
+		}
+
+		wasStack = isStackLine
+	}
+
+	// Use up stack
+	if stack != "" {
+		blocks = append(blocks, stack)
+	}
+	return blocks, nil
+}
+
+func testFormatCompleteCompare(t *testing.T, n int, arg interface{}, format string, want []string, detectStackBoundaries bool) {
+	gotStr := fmt.Sprintf(format, arg)
+
+	got, err := parseBlocks(gotStr, detectStackBoundaries)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("test %d: fmt.Sprintf(%s, err) -> wrong number of blocks: got(%d) want(%d)\n got: %s\nwant: %s\ngotStr: %q",
+			n+1, format, len(got), len(want), prettyBlocks(got), prettyBlocks(want), gotStr)
+	}
+
+	for i := range got {
+		if strings.ContainsAny(want[i], "\n") {
+			// Match as stack
+			match, err := regexp.MatchString(want[i], got[i])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !match {
+				t.Fatalf("test %d: block %d: fmt.Sprintf(%q, err):\ngot:\n%q\nwant:\n%q\nall-got:\n%s\nall-want:\n%s\n",
+					n+1, i+1, format, got[i], want[i], prettyBlocks(got), prettyBlocks(want))
+			}
+		} else {
+			// Match as message
+			if got[i] != want[i] {
+				t.Fatalf("test %d: fmt.Sprintf(%s, err) at block %d got != want:\n got: %q\nwant: %q", n+1, format, i+1, got[i], want[i])
+			}
+		}
+	}
+}
+
+type wrapper struct {
+	wrap func(err error) error
+	want []string
+}
+
+func prettyBlocks(blocks []string, prefix ...string) string {
+	var out []string
+
+	for _, b := range blocks {
+		out = append(out, fmt.Sprintf("%v", b))
+	}
+
+	return "   " + strings.Join(out, "\n   ")
+}
+
+func testGenericRecursive(t *testing.T, beforeErr error, beforeWant []string, list []wrapper, maxDepth int) {
+	if len(beforeWant) == 0 {
+		panic("beforeWant must not be empty")
+	}
+	for _, w := range list {
+		if len(w.want) == 0 {
+			panic("want must not be empty")
+		}
+
+		err := w.wrap(beforeErr)
+
+		// Copy required cause append(beforeWant, ..) modified beforeWant subtly.
+		beforeCopy := make([]string, len(beforeWant))
+		copy(beforeCopy, beforeWant)
+
+		beforeWant := beforeCopy
+		last := len(beforeWant) - 1
+		var want []string
+
+		// Merge two stacks behind each other.
+		if strings.ContainsAny(beforeWant[last], "\n") && strings.ContainsAny(w.want[0], "\n") {
+			want = append(beforeWant[:last], append([]string{beforeWant[last] + "((?s).*)" + w.want[0]}, w.want[1:]...)...)
+		} else {
+			want = append(beforeWant, w.want...)
+		}
+
+		testFormatCompleteCompare(t, maxDepth, err, "%+v", want, false)
+		if maxDepth > 0 {
+			testGenericRecursive(t, err, want, list, maxDepth-1)
+		}
+	}
+}

--- a/deps/github.com/pkg/errors/stack.go
+++ b/deps/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}

--- a/deps/github.com/pkg/errors/stack_test.go
+++ b/deps/github.com/pkg/errors/stack_test.go
@@ -1,0 +1,292 @@
+package errors
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+var initpc, _, _, _ = runtime.Caller(0)
+
+func TestFrameLine(t *testing.T) {
+	var tests = []struct {
+		Frame
+		want int
+	}{{
+		Frame(initpc),
+		9,
+	}, {
+		func() Frame {
+			var pc, _, _, _ = runtime.Caller(0)
+			return Frame(pc)
+		}(),
+		20,
+	}, {
+		func() Frame {
+			var pc, _, _, _ = runtime.Caller(1)
+			return Frame(pc)
+		}(),
+		28,
+	}, {
+		Frame(0), // invalid PC
+		0,
+	}}
+
+	for _, tt := range tests {
+		got := tt.Frame.line()
+		want := tt.want
+		if want != got {
+			t.Errorf("Frame(%v): want: %v, got: %v", uintptr(tt.Frame), want, got)
+		}
+	}
+}
+
+type X struct{}
+
+func (x X) val() Frame {
+	var pc, _, _, _ = runtime.Caller(0)
+	return Frame(pc)
+}
+
+func (x *X) ptr() Frame {
+	var pc, _, _, _ = runtime.Caller(0)
+	return Frame(pc)
+}
+
+func TestFrameFormat(t *testing.T) {
+	var tests = []struct {
+		Frame
+		format string
+		want   string
+	}{{
+		Frame(initpc),
+		"%s",
+		"stack_test.go",
+	}, {
+		Frame(initpc),
+		"%+s",
+		"github.com/pkg/errors.init\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go",
+	}, {
+		Frame(0),
+		"%s",
+		"unknown",
+	}, {
+		Frame(0),
+		"%+s",
+		"unknown",
+	}, {
+		Frame(initpc),
+		"%d",
+		"9",
+	}, {
+		Frame(0),
+		"%d",
+		"0",
+	}, {
+		Frame(initpc),
+		"%n",
+		"init",
+	}, {
+		func() Frame {
+			var x X
+			return x.ptr()
+		}(),
+		"%n",
+		`\(\*X\).ptr`,
+	}, {
+		func() Frame {
+			var x X
+			return x.val()
+		}(),
+		"%n",
+		"X.val",
+	}, {
+		Frame(0),
+		"%n",
+		"",
+	}, {
+		Frame(initpc),
+		"%v",
+		"stack_test.go:9",
+	}, {
+		Frame(initpc),
+		"%+v",
+		"github.com/pkg/errors.init\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:9",
+	}, {
+		Frame(0),
+		"%v",
+		"unknown:0",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.Frame, tt.format, tt.want)
+	}
+}
+
+func TestFuncname(t *testing.T) {
+	tests := []struct {
+		name, want string
+	}{
+		{"", ""},
+		{"runtime.main", "main"},
+		{"github.com/pkg/errors.funcname", "funcname"},
+		{"funcname", "funcname"},
+		{"io.copyBuffer", "copyBuffer"},
+		{"main.(*R).Write", "(*R).Write"},
+	}
+
+	for _, tt := range tests {
+		got := funcname(tt.name)
+		want := tt.want
+		if got != want {
+			t.Errorf("funcname(%q): want: %q, got %q", tt.name, want, got)
+		}
+	}
+}
+
+func TestTrimGOPATH(t *testing.T) {
+	var tests = []struct {
+		Frame
+		want string
+	}{{
+		Frame(initpc),
+		"github.com/pkg/errors/stack_test.go",
+	}}
+
+	for i, tt := range tests {
+		pc := tt.Frame.pc()
+		fn := runtime.FuncForPC(pc)
+		file, _ := fn.FileLine(pc)
+		got := trimGOPATH(fn.Name(), file)
+		testFormatRegexp(t, i, got, "%s", tt.want)
+	}
+}
+
+func TestStackTrace(t *testing.T) {
+	tests := []struct {
+		err  error
+		want []string
+	}{{
+		New("ooh"), []string{
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:172",
+		},
+	}, {
+		Wrap(New("ooh"), "ahh"), []string{
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:177", // this is the stack of Wrap, not New
+		},
+	}, {
+		Cause(Wrap(New("ooh"), "ahh")), []string{
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:182", // this is the stack of New
+		},
+	}, {
+		func() error { return New("ooh") }(), []string{
+			`github.com/pkg/errors.(func·009|TestStackTrace.func1)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:187", // this is the stack of New
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:187", // this is the stack of New's caller
+		},
+	}, {
+		Cause(func() error {
+			return func() error {
+				return Errorf("hello %s", fmt.Sprintf("world"))
+			}()
+		}()), []string{
+			`github.com/pkg/errors.(func·010|TestStackTrace.func2.1)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:196", // this is the stack of Errorf
+			`github.com/pkg/errors.(func·011|TestStackTrace.func2)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:197", // this is the stack of Errorf's caller
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:198", // this is the stack of Errorf's caller's caller
+		},
+	}}
+	for i, tt := range tests {
+		x, ok := tt.err.(interface {
+			StackTrace() StackTrace
+		})
+		if !ok {
+			t.Errorf("expected %#v to implement StackTrace() StackTrace", tt.err)
+			continue
+		}
+		st := x.StackTrace()
+		for j, want := range tt.want {
+			testFormatRegexp(t, i, st[j], "%+v", want)
+		}
+	}
+}
+
+func stackTrace() StackTrace {
+	const depth = 8
+	var pcs [depth]uintptr
+	n := runtime.Callers(1, pcs[:])
+	var st stack = pcs[0:n]
+	return st.StackTrace()
+}
+
+func TestStackTraceFormat(t *testing.T) {
+	tests := []struct {
+		StackTrace
+		format string
+		want   string
+	}{{
+		nil,
+		"%s",
+		`\[\]`,
+	}, {
+		nil,
+		"%v",
+		`\[\]`,
+	}, {
+		nil,
+		"%+v",
+		"",
+	}, {
+		nil,
+		"%#v",
+		`\[\]errors.Frame\(nil\)`,
+	}, {
+		make(StackTrace, 0),
+		"%s",
+		`\[\]`,
+	}, {
+		make(StackTrace, 0),
+		"%v",
+		`\[\]`,
+	}, {
+		make(StackTrace, 0),
+		"%+v",
+		"",
+	}, {
+		make(StackTrace, 0),
+		"%#v",
+		`\[\]errors.Frame{}`,
+	}, {
+		stackTrace()[:2],
+		"%s",
+		`\[stack_test.go stack_test.go\]`,
+	}, {
+		stackTrace()[:2],
+		"%v",
+		`\[stack_test.go:225 stack_test.go:272\]`,
+	}, {
+		stackTrace()[:2],
+		"%+v",
+		"\n" +
+			"github.com/pkg/errors.stackTrace\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:225\n" +
+			"github.com/pkg/errors.TestStackTraceFormat\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:276",
+	}, {
+		stackTrace()[:2],
+		"%#v",
+		`\[\]errors.Frame{stack_test.go:225, stack_test.go:284}`,
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.StackTrace, tt.format, tt.want)
+	}
+}

--- a/pkg/kubernetes/downward_api.go
+++ b/pkg/kubernetes/downward_api.go
@@ -1,0 +1,21 @@
+package kubernetes
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+const (
+	namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
+// GetKubernetesNamespace loads the namespace of the pod running this process.
+// If the namespace is not found, (e.g. because the process is not running in kubernetes)
+// an empty string is returned.
+func GetKubernetesNamespace() string {
+	raw, err := ioutil.ReadFile(namespacePath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}

--- a/service/backend/k8s_backend.go
+++ b/service/backend/k8s_backend.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	announceLabel                  = "pulcy.com/correlation"
-	announceRegistrationAnnotation = "pulcy.com/correlation/registration"
+	announceRegistrationAnnotation = "pulcy_com_correlation_registration"
 )
 
 type k8sBackend struct {

--- a/service/backend/k8s_backend.go
+++ b/service/backend/k8s_backend.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	k8s "github.com/YakLabs/k8s-client"
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/juju/errgo"
+	"github.com/op/go-logging"
+)
+
+const (
+	announceLabel                  = "pulcy.com/correlation"
+	announceRegistrationAnnotation = "pulcy.com/correlation/registration"
+)
+
+type k8sBackend struct {
+	client              k8s.Client
+	namespace           string
+	podName             string
+	labelSelectionValue string
+	Logger              *logging.Logger
+	lastState           string
+	last                DeviceRegistrations
+
+	announceMutex    sync.Mutex
+	announceStarted  bool
+	announceDeviceID string
+	announceAddress  string
+}
+
+func NewKubernetesBackend(logger *logging.Logger, namespace, podName, labelSelectionValue string) (Backend, error) {
+	c, err := http.NewInCluster()
+	if err != nil {
+		return nil, maskAny(err)
+	}
+	if namespace == "" {
+		return nil, maskAny(fmt.Errorf("namespace not set"))
+	}
+	if podName == "" {
+		return nil, maskAny(fmt.Errorf("podName not set"))
+	}
+	if labelSelectionValue == "" {
+		return nil, maskAny(fmt.Errorf("labelSelectionValue not set"))
+	}
+
+	// Fetch pod
+	if _, err := c.GetPod(namespace, podName); err != nil {
+		return nil, maskAny(errgo.Notef(err, "failed to get pod '%s': %v", podName, err))
+	}
+
+	return &k8sBackend{
+		client:              c,
+		namespace:           namespace,
+		podName:             podName,
+		labelSelectionValue: labelSelectionValue,
+		Logger:              logger,
+	}, nil
+}
+
+// Watch for changes on a path and return where there is a change.
+func (b *k8sBackend) Watch() error {
+	for {
+		regs, err := b.get()
+		if err != nil {
+			b.Logger.Warningf("failed to get registrations: %v", err)
+		} else {
+			state := regs.FullString()
+			if state != b.lastState {
+				// There is a change
+				b.lastState = state
+				b.last = regs
+				return nil
+			}
+		}
+		time.Sleep(time.Second * 5)
+	}
+}
+
+// Load all registered devices
+func (b *k8sBackend) Get() (DeviceRegistrations, error) {
+	if regs := b.last; regs != nil {
+		return regs, nil
+	}
+	regs, err := b.get()
+	if err != nil {
+		return nil, maskAny(err)
+	}
+	b.last = regs
+	return regs, nil
+}
+
+// Announce the given device that can be found at the given address
+func (b *k8sBackend) Announce(deviceID, address string) {
+	if deviceID == "" || address == "" {
+		b.UnAnnounce()
+		return
+	}
+
+	// Create registration
+	reg, err := b.parseAddress(address)
+	if err != nil {
+		b.Logger.Errorf("Failed to parse address: %#v", err)
+		return
+	}
+	reg.ID = deviceID
+
+	// Create JSON
+	raw, err := json.Marshal(reg)
+	if err != nil {
+		b.Logger.Errorf("Failed to marshal registration to JSON: %#v", err)
+		return
+	}
+
+	// Record in Kubernetes data
+	b.updateAnnounce(string(raw))
+}
+
+// UnAnnounce removes the current announcement
+func (b *k8sBackend) UnAnnounce() {
+	b.Logger.Debugf("removing device announcements")
+	b.updateAnnounce("")
+}
+
+// Announce the configured device that can be found at the configured address
+func (b *k8sBackend) updateAnnounce(annotationValue string) {
+	for i := 0; i < 25; i++ {
+		if err := b.updateAnnounceOnce(annotationValue); err != nil {
+			b.Logger.Warningf("Failed to update announcement: %#v", err)
+			time.Sleep(time.Second * 2)
+		} else {
+			// We're done
+			return
+		}
+	}
+}
+
+// Announce the configured device that can be found at the configured address
+func (b *k8sBackend) updateAnnounceOnce(annotationValue string) error {
+	pod, err := b.client.GetPod(b.namespace, b.podName)
+	if err != nil {
+		return maskAny(err)
+	}
+
+	// Update labels
+	if pod.ObjectMeta.Labels == nil {
+		pod.ObjectMeta.Labels = make(map[string]string)
+	}
+	pod.ObjectMeta.Labels[announceLabel] = b.labelSelectionValue
+
+	// Update annotations
+	if pod.ObjectMeta.Annotations == nil {
+		pod.ObjectMeta.Annotations = make(map[string]string)
+	}
+	pod.ObjectMeta.Annotations[announceRegistrationAnnotation] = annotationValue
+
+	// Update pod
+	if _, err := b.client.UpdatePod(b.namespace, pod); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
+// Load all registered devices
+func (b *k8sBackend) get() (DeviceRegistrations, error) {
+	// Find all matching pods
+	options := &k8s.ListOptions{
+		LabelSelector: k8s.LabelSelector{
+			MatchLabels: map[string]string{
+				announceLabel: b.labelSelectionValue,
+			},
+		},
+	}
+	pods, err := b.client.ListPods(b.namespace, options)
+	if err != nil {
+		return nil, maskAny(err)
+	}
+
+	var regs DeviceRegistrations
+	for _, pod := range pods.Items {
+		ann, ok := pod.ObjectMeta.Annotations[announceRegistrationAnnotation]
+		if !ok || ann == "" {
+			b.Logger.Debugf("Pod %s has no registration annotation", pod.Name)
+			continue
+		}
+		var reg DeviceRegistration
+		if err := json.Unmarshal([]byte(ann), &reg); err != nil {
+			b.Logger.Debugf("Failed to parse registration annotation from pod %s: %#v", pod.Name, err)
+			continue
+		}
+		regs = append(regs, reg)
+	}
+
+	return regs, nil
+}
+
+// parseAddress parses a string in the format of "<ip>':'<port>" into a DeviceRegistration.
+func (b *k8sBackend) parseAddress(s string) (DeviceRegistration, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return DeviceRegistration{}, maskAny(fmt.Errorf("Invalid device '%s'", s))
+	}
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return DeviceRegistration{}, maskAny(fmt.Errorf("Invalid device port '%s' in '%s'", parts[1], s))
+	}
+	return DeviceRegistration{
+		IP:   parts[0],
+		Port: port,
+	}, nil
+}

--- a/service/kubernetes.go
+++ b/service/kubernetes.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"github.com/YakLabs/k8s-client/http"
+	"github.com/juju/errgo"
+	"github.com/op/go-logging"
+)
+
+// UpdateConfigFromKubernetes fills the AnnounceIP & Port from kubernetes.
+func UpdateConfigFromKubernetes(log *logging.Logger, cfg ServiceConfig, namespace, podName string) (ServiceConfig, error) {
+	if cfg.AnnounceIP != "" && cfg.AnnouncePort != 0 {
+		return cfg, nil
+	}
+	if namespace == "" || podName == "" {
+		return cfg, nil
+	}
+
+	c, err := http.NewInCluster()
+	if err != nil {
+		return cfg, maskAny(err)
+	}
+
+	// Fetch pod
+	pod, err := c.GetPod(namespace, podName)
+	if err != nil {
+		return cfg, maskAny(errgo.Notef(err, "failed to get pod '%s': %v", podName, err))
+	}
+
+	cfg.AnnounceIP = pod.Status.PodIP
+	log.Debugf("using AnnounceIP '%s'", cfg.AnnounceIP)
+	cfg.AnnouncePort = cfg.SyncPort
+	log.Debugf("using AccountPort %d", cfg.AnnouncePort)
+	return cfg, nil
+}


### PR DESCRIPTION
This PR adds native support for running Correlation in Kubernetes.
When Kubernetes is detected, it switched on a new backend and it will not use ETCD at all.

The backend adds a label to the pod it is running in an a device address in an annotation (in the same pod).
Correlation instances can find each other using the label and know where to connect to using the annotation.

Example:
```
Label:
pulcy.com/correlation: pulcy_correlation_arangodb_arangodb3

Annotation:
pulcy_com_correlation_registration: {\"ID\":\"JCF5NIC-6ST2FFV-3X7CJQW-H2ZDBMH-J7RUSTE-WWL2CWU-T2BWC6R-XJYX3AD\",\"IP\":\"10.38.0.2\",\"Port\":5808}
```
